### PR TITLE
Skip plant fertilization if we don't have fertilizer

### DIFF
--- a/Helpers/GardenHelper.cs
+++ b/Helpers/GardenHelper.cs
@@ -146,6 +146,13 @@ namespace LlamaLibrary.Helpers
                 }
             }
 
+            var slots = GeneralFunctions.MainBagsFilledSlots().Where(x => x.RawItemId == 7767);
+            Log.Information($"Found {slots.Count()} slots filled with fish meal.");
+            if (slots.Count() < 1)
+            {
+                Log.Information($"No fertilizer in bag, skipping fertilize.");
+                return true;
+            }
             var plants = GardenManager.Plants.Where(r => r.Distance2D(gardenLoc) < 10).ToArray();
             foreach (var plant in plants)
             {


### PR DESCRIPTION
Currently using the GoGarden function (e.g. via Lurch) will click every plant to try and fertilize it even though there is no chance to fertilize it because the needed item is missing.

Not only does that give an ugly error message, it also wastes a lot of time depending on number of plots to check.