### PR TITLE
Introduce a wrapper around CallInjected64

### DIFF
--- a/ClientDataHelpers/AtkArrayDataHolder.cs
+++ b/ClientDataHelpers/AtkArrayDataHolder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using ff14bot;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.ClientDataHelpers
 {
@@ -31,12 +32,12 @@ namespace LlamaLibrary.ClientDataHelpers
 
         public static IntPtr GetNumberArray(int index)
         {
-            return Core.Memory.CallInjected64<IntPtr>(GetNumArrayFunction, RaptureAtkModule, index);
+            return Core.Memory.CallInjectedWraper<IntPtr>(GetNumArrayFunction, RaptureAtkModule, index);
         }
 
         public static IntPtr GetStringArray(int index)
         {
-            return Core.Memory.CallInjected64<IntPtr>(GetStringArrayFunction, RaptureAtkModule, index);
+            return Core.Memory.CallInjectedWraper<IntPtr>(GetStringArrayFunction, RaptureAtkModule, index);
         }
     }
 }

--- a/ClientDataHelpers/UiManagerProxy.cs
+++ b/ClientDataHelpers/UiManagerProxy.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using ff14bot;
 using LlamaLibrary.Memory;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.ClientDataHelpers;
 
@@ -27,42 +28,42 @@ public static class UiManagerProxy
 
     static UiManagerProxy()
     {
-       // _uiModule = Core.Memory.CallInjected64<IntPtr>(Offsets.GetUiModule, Core.Memory.Read<IntPtr>(Offsets.Framework));
+       // _uiModule = Core.Memory.CallInjectedWraper<IntPtr>(Offsets.GetUiModule, Core.Memory.Read<IntPtr>(Offsets.Framework));
     }
 
-    public static IntPtr GoldSaucerModule { get; } = Core.Memory.CallInjected64<IntPtr>(VFunctionAddress(VFunctionIds["GoldSaucerModule"]), UIModule);
+    public static IntPtr GoldSaucerModule { get; } = Core.Memory.CallInjectedWraper<IntPtr>(VFunctionAddress(VFunctionIds["GoldSaucerModule"]), UIModule);
 
-    public static IntPtr AcquaintanceModule { get; } = Core.Memory.CallInjected64<IntPtr>(VFunctionAddress(VFunctionIds["AcquaintanceModule"]), UIModule);
+    public static IntPtr AcquaintanceModule { get; } = Core.Memory.CallInjectedWraper<IntPtr>(VFunctionAddress(VFunctionIds["AcquaintanceModule"]), UIModule);
 
-    public static IntPtr FieldMarkerModule { get; } = Core.Memory.CallInjected64<IntPtr>(VFunctionAddress(VFunctionIds["GetFieldMarkerModule"]), UIModule);
+    public static IntPtr FieldMarkerModule { get; } = Core.Memory.CallInjectedWraper<IntPtr>(VFunctionAddress(VFunctionIds["GetFieldMarkerModule"]), UIModule);
 
-    public static IntPtr RecommendEquipModule { get; } = Core.Memory.CallInjected64<IntPtr>(VFunctionAddress(VFunctionIds["GetRecommendEquipModule"]), UIModule);
+    public static IntPtr RecommendEquipModule { get; } = Core.Memory.CallInjectedWraper<IntPtr>(VFunctionAddress(VFunctionIds["GetRecommendEquipModule"]), UIModule);
 
     //public static IntPtr UIModule => (IntPtr)Properties.First(i => i.Name.Equals("UIModule")).GetValue(null);
 
-    public static IntPtr UIModule => _uiModule == IntPtr.Zero ? _uiModule = Core.Memory.CallInjected64<IntPtr>(Offsets.GetUiModule, Core.Memory.Read<IntPtr>(Offsets.Framework)) : _uiModule;
+    public static IntPtr UIModule => _uiModule == IntPtr.Zero ? _uiModule = Core.Memory.CallInjectedWraper<IntPtr>(Offsets.GetUiModule, Core.Memory.Read<IntPtr>(Offsets.Framework)) : _uiModule;
 
-    public static IntPtr InfoModule { get; } = Core.Memory.CallInjected64<IntPtr>(VFunctionAddress(VFunctionIds["GetInfoModule"]), UIModule);
+    public static IntPtr InfoModule { get; } = Core.Memory.CallInjectedWraper<IntPtr>(VFunctionAddress(VFunctionIds["GetInfoModule"]), UIModule);
 
-    public static IntPtr RaptureTextModule => Core.Memory.CallInjected64<IntPtr>(VFunctionAddress(VFunctionIds["GetRaptureTextModule"]), UIModule);
+    public static IntPtr RaptureTextModule => Core.Memory.CallInjectedWraper<IntPtr>(VFunctionAddress(VFunctionIds["GetRaptureTextModule"]), UIModule);
 
-    public static IntPtr UIInputData => Core.Memory.CallInjected64<IntPtr>(VFunctionAddress(VFunctionIds["GetUIInputData"]), UIModule);
+    public static IntPtr UIInputData => Core.Memory.CallInjectedWraper<IntPtr>(VFunctionAddress(VFunctionIds["GetUIInputData"]), UIModule);
 
-    public static IntPtr UIInputModule => Core.Memory.CallInjected64<IntPtr>(VFunctionAddress(VFunctionIds["GetUIInputModule"]), UIModule);
+    public static IntPtr UIInputModule => Core.Memory.CallInjectedWraper<IntPtr>(VFunctionAddress(VFunctionIds["GetUIInputModule"]), UIModule);
 
-    public static IntPtr UIInputModule_Topic2 => Core.Memory.CallInjected64<IntPtr>(VFunctionAddress(VFunctionIds["GetUIInputModule_Topic"]), UIModule);
+    public static IntPtr UIInputModule_Topic2 => Core.Memory.CallInjectedWraper<IntPtr>(VFunctionAddress(VFunctionIds["GetUIInputModule_Topic"]), UIModule);
 
     //public static IntPtr RaptureAtkModule => (IntPtr)Properties.First(i => i.Name.Equals("RaptureAtkModule")).GetValue(null);
 
-    public static IntPtr RaptureAtkModule => Core.Memory.CallInjected64<IntPtr>(VFunctionAddress(VFunctionIds["GetRaptureAtkModule"]), UIModule);
+    public static IntPtr RaptureAtkModule => Core.Memory.CallInjectedWraper<IntPtr>(VFunctionAddress(VFunctionIds["GetRaptureAtkModule"]), UIModule);
 
     //public static IntPtr RaptureShellModule => (IntPtr)Properties.First(i => i.Name.Equals("RaptureShellModule")).GetValue(null);
 
-    public static IntPtr RaptureShellModule => Core.Memory.CallInjected64<IntPtr>(VFunctionAddress(VFunctionIds["GetRaptureShellModule"]), UIModule);
+    public static IntPtr RaptureShellModule => Core.Memory.CallInjectedWraper<IntPtr>(VFunctionAddress(VFunctionIds["GetRaptureShellModule"]), UIModule);
 
     public static IntPtr VFunctionCall(int index)
     {
-        return Core.Memory.CallInjected64<IntPtr>(VFunctionAddress(index), UIModule);
+        return Core.Memory.CallInjectedWraper<IntPtr>(VFunctionAddress(index), UIModule);
     }
 
     public static IntPtr VFunctionAddress(int index)

--- a/Directors/OutOnALimbDirector.cs
+++ b/Directors/OutOnALimbDirector.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using ff14bot;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Directors
 {
@@ -82,7 +83,7 @@ namespace LlamaLibrary.Directors
                     return -1;
                 }
 
-                return Core.Memory.CallInjected64<int>(Offsets.RemainingTimeFunction, Offsets.ActiveDirectorPtr);
+                return Core.Memory.CallInjectedWraper<int>(Offsets.RemainingTimeFunction, Offsets.ActiveDirectorPtr);
             }
         }
 

--- a/Extensions/BagSlotExtensions.cs
+++ b/Extensions/BagSlotExtensions.cs
@@ -14,6 +14,7 @@ using LlamaLibrary.Helpers.Ping;
 using LlamaLibrary.JsonObjects;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.RemoteAgents;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Extensions
 {
@@ -177,7 +178,7 @@ namespace LlamaLibrary.Extensions
                 {
                     using (Core.Memory.TemporaryCacheState(false))
                     {
-                        return Core.Memory.CallInjected64<uint>(Offsets.ItemSplitFunc,
+                        return Core.Memory.CallInjectedWraper<uint>(Offsets.ItemSplitFunc,
                                                                 Memory.Offsets.g_InventoryManager,
                                                                 (uint)bagSlot.BagId,
                                                                 bagSlot.Slot,
@@ -193,7 +194,7 @@ namespace LlamaLibrary.Extensions
         {
             lock (Core.Memory.Executor.AssemblyLock)
             {
-                Core.Memory.CallInjected64<uint>(Offsets.ItemDiscardFunc,
+                Core.Memory.CallInjectedWraper<uint>(Offsets.ItemDiscardFunc,
                                                  Memory.Offsets.g_InventoryManager,
                                                  (uint)bagSlot.BagId,
                                                  bagSlot.Slot);
@@ -204,7 +205,7 @@ namespace LlamaLibrary.Extensions
         {
             lock (Core.Memory.Executor.AssemblyLock)
             {
-                Core.Memory.CallInjected64<uint>(Offsets.RemoveMateriaFunc,
+                Core.Memory.CallInjectedWraper<uint>(Offsets.RemoveMateriaFunc,
                                                  Offsets.EventHandler,
                                                  Offsets.DesynthId,
                                                  (uint)bagSlot.BagId,
@@ -221,7 +222,7 @@ namespace LlamaLibrary.Extensions
                 {
                     using (Core.Memory.TemporaryCacheState(false))
                     {
-                        Core.Memory.CallInjected64<uint>(Offsets.ItemLowerQualityFunc,
+                        Core.Memory.CallInjectedWraper<uint>(Offsets.ItemLowerQualityFunc,
                                                          Memory.Offsets.g_InventoryManager,
                                                          (uint)bagSlot.BagId,
                                                          bagSlot.Slot);
@@ -238,7 +239,7 @@ namespace LlamaLibrary.Extensions
         {
             lock (Core.Memory.Executor.AssemblyLock)
             {
-                Core.Memory.CallInjected64<uint>(Offsets.RemoveMateriaFunc,
+                Core.Memory.CallInjectedWraper<uint>(Offsets.RemoveMateriaFunc,
                                                  Offsets.EventHandler,
                                                  Offsets.ReduceId,
                                                  (uint)bagSlot.BagId,
@@ -258,7 +259,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    Core.Memory.CallInjected64<uint>(Offsets.RetainerRetrieveQuantity,
+                    Core.Memory.CallInjectedWraper<uint>(Offsets.RetainerRetrieveQuantity,
                                                      Memory.Offsets.g_InventoryManager,
                                                      (uint)bagSlot.BagId,
                                                      bagSlot.Slot,
@@ -273,7 +274,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    Core.Memory.CallInjected64<uint>(Offsets.EntrustRetainerFunc,
+                    Core.Memory.CallInjectedWraper<uint>(Offsets.EntrustRetainerFunc,
                                                      AgentRetainerInventory.Instance.Pointer,
                                                      0,
                                                      (uint)bagSlot.BagId,
@@ -289,7 +290,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    Core.Memory.CallInjected64<uint>(Offsets.SellFunc,
+                    Core.Memory.CallInjectedWraper<uint>(Offsets.SellFunc,
                                                      AgentRetainerInventory.Instance.RetainerShopPointer,
                                                      bagSlot.Slot,
                                                      (uint)bagSlot.BagId,
@@ -304,7 +305,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    Core.Memory.CallInjected64<uint>(Offsets.SellFunc,
+                    Core.Memory.CallInjectedWraper<uint>(Offsets.SellFunc,
                                                      Shop.ActiveShopPtr,
                                                      bagSlot.Slot,
                                                      (uint)bagSlot.BagId,
@@ -317,7 +318,7 @@ namespace LlamaLibrary.Extensions
         {
             lock (Core.Memory.Executor.AssemblyLock)
             {
-                Core.Memory.CallInjected64<uint>(Offsets.RemoveMateriaFunc,
+                Core.Memory.CallInjectedWraper<uint>(Offsets.RemoveMateriaFunc,
                                                  Offsets.EventHandler,
                                                  Offsets.RemoveMateriaId,
                                                  (uint)bagSlot.BagId,
@@ -337,7 +338,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    Core.Memory.CallInjected64<uint>(Offsets.ExtractMateriaFunc,
+                    Core.Memory.CallInjectedWraper<uint>(Offsets.ExtractMateriaFunc,
                                                      Offsets.ExtractMateriaParam,
                                                      (uint)bagSlot.BagId,
                                                      bagSlot.Slot);
@@ -352,7 +353,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    Core.Memory.CallInjected64<IntPtr>(Offsets.MeldItem,
+                    Core.Memory.CallInjectedWraper<IntPtr>(Offsets.MeldItem,
                                                        (int)Equipment.BagId,
                                                        (short)Equipment.Slot,
                                                        (int)Materia.BagId,
@@ -369,7 +370,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    Core.Memory.CallInjected64<uint>(Offsets.MeldWindowFunc,
+                    Core.Memory.CallInjectedWraper<uint>(Offsets.MeldWindowFunc,
                                                      AgentMeld.Instance.Pointer,
                                                      bagSlot.Pointer);
                 }
@@ -382,7 +383,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    return Core.Memory.CallInjected64<uint>(Offsets.GetPostingPriceSlot,
+                    return Core.Memory.CallInjectedWraper<uint>(Offsets.GetPostingPriceSlot,
                                                             Memory.Offsets.g_InventoryManager,
                                                             slot.Slot);
                 }
@@ -449,7 +450,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    result = Core.Memory.CallInjected64<uint>(Offsets.TradeBagSlot,
+                    result = Core.Memory.CallInjectedWraper<uint>(Offsets.TradeBagSlot,
                                                               Memory.Offsets.g_InventoryManager,
                                                               bagSlot.Slot,
                                                               (uint)bagSlot.BagId);
@@ -460,7 +461,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    Core.Memory.CallInjected64<uint>(Offsets.TradeBagSlot,
+                    Core.Memory.CallInjectedWraper<uint>(Offsets.TradeBagSlot,
                                                      Memory.Offsets.g_InventoryManager,
                                                      bagSlot.Slot,
                                                      (uint)bagSlot.BagId);
@@ -499,7 +500,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    return Core.Memory.CallInjected64<byte>(Offsets.BagSlotUseItem,
+                    return Core.Memory.CallInjectedWraper<byte>(Offsets.BagSlotUseItem,
                                                             InventoryManager,
                                                             TrueItemId,
                                                             inventoryContainer,
@@ -514,7 +515,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    return Core.Memory.CallInjected64<IntPtr>(Offsets.RemoveFromSaddle,
+                    return Core.Memory.CallInjectedWraper<IntPtr>(Offsets.RemoveFromSaddle,
                                                               InventoryManager,
                                                               inventoryContainer,
                                                               inventorySlot,
@@ -529,7 +530,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    return Core.Memory.CallInjected64<IntPtr>(Offsets.AddToSaddle,
+                    return Core.Memory.CallInjectedWraper<IntPtr>(Offsets.AddToSaddle,
                                                               InventoryManager,
                                                               inventoryContainer,
                                                               inventorySlot,
@@ -544,7 +545,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    return Core.Memory.CallInjected64<IntPtr>(Offsets.PlaceAetherWheel,
+                    return Core.Memory.CallInjectedWraper<IntPtr>(Offsets.PlaceAetherWheel,
                                                               AgentBagSlot.Instance.PointerForAether,
                                                               (int)inventorySlot,
                                                               inventoryContainer);
@@ -556,7 +557,7 @@ namespace LlamaLibrary.Extensions
         {
             lock (Core.Memory.Executor.AssemblyLock)
             {
-                return Core.Memory.CallInjected64<IntPtr>(Offsets.FCChestMove,
+                return Core.Memory.CallInjectedWraper<IntPtr>(Offsets.FCChestMove,
                                                           AgentFreeCompanyChest.Instance.Pointer,
                                                           sourceContainer,
                                                           sourceSlot,
@@ -581,7 +582,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    Core.Memory.CallInjected64<uint>(Offsets.StoreroomToInventory,
+                    Core.Memory.CallInjectedWraper<uint>(Offsets.StoreroomToInventory,
                                                      HousingHelper.PositionPointer,
                                                      bagSlot.Pointer);
                 }
@@ -601,7 +602,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    Core.Memory.CallInjected64<uint>(Offsets.InventoryToStoreroom,
+                    Core.Memory.CallInjectedWraper<uint>(Offsets.InventoryToStoreroom,
                                                      HousingHelper.PositionPointer,
                                                      bagSlot.Pointer);
                 }
@@ -631,7 +632,7 @@ namespace LlamaLibrary.Extensions
             {
                 using (Core.Memory.TemporaryCacheState(false))
                 {
-                    return Core.Memory.CallInjected64<byte>(Offsets.DyeItem,
+                    return Core.Memory.CallInjectedWraper<byte>(Offsets.DyeItem,
                                                             Memory.Offsets.g_InventoryManager,
                                                             item.BagId,
                                                             item.Slot,

--- a/Extensions/EventNpcExtensions.cs
+++ b/Extensions/EventNpcExtensions.cs
@@ -3,6 +3,7 @@ using ff14bot;
 using ff14bot.Enums;
 using ff14bot.Objects;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Extensions
 {
@@ -22,7 +23,7 @@ namespace LlamaLibrary.Extensions
 
         public static int OpenTradeWindow(this BattleCharacter otherPlayer)
         {
-            return otherPlayer.Type == GameObjectType.Pc ? Core.Memory.CallInjected64<IntPtr>(Memory.Offsets.OpenTradeWindow, Memory.Offsets.g_InventoryManager, otherPlayer.ObjectId).ToInt32() : -1;
+            return otherPlayer.Type == GameObjectType.Pc ? Core.Memory.CallInjectedWraper<IntPtr>(Memory.Offsets.OpenTradeWindow, Memory.Offsets.g_InventoryManager, otherPlayer.ObjectId).ToInt32() : -1;
         }
     }
 }

--- a/Extensions/LocalPlayerExtensions.cs
+++ b/Extensions/LocalPlayerExtensions.cs
@@ -7,6 +7,7 @@ using ff14bot.Objects;
 using LlamaLibrary.Enums;
 using LlamaLibrary.Helpers.NPC;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Extensions
 {
@@ -126,7 +127,7 @@ namespace LlamaLibrary.Extensions
             IntPtr rankRow;
             lock (Core.Memory.Executor.AssemblyLock)
             {
-                rankRow = Core.Memory.CallInjected64<IntPtr>(Offsets.GCGetMaxSealsByRank,
+                rankRow = Core.Memory.CallInjectedWraper<IntPtr>(Offsets.GCGetMaxSealsByRank,
                                                              gcRank);
             }
 

--- a/Helpers/Achievements.cs
+++ b/Helpers/Achievements.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Buddy.Coroutines;
 using ff14bot;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers
 {
@@ -49,7 +50,7 @@ namespace LlamaLibrary.Helpers
 
         public static void RequestAchievement(int achievementId)
         {
-            Core.Memory.CallInjected64<byte>(Offsets.RequestAchievementFunction, Offsets.AchievementInstancePtr, achievementId);
+            Core.Memory.CallInjectedWraper<byte>(Offsets.RequestAchievementFunction, Offsets.AchievementInstancePtr, achievementId);
         }
 
         public static bool HasAchievement(int achievementId)
@@ -58,7 +59,7 @@ namespace LlamaLibrary.Helpers
 
             lock (Core.Memory.Executor.AssemblyLock)
             {
-                done = Core.Memory.CallInjected64<bool>(Offsets.IsCompletePtr, Offsets.AchievementInstancePtr, achievementId);
+                done = Core.Memory.CallInjectedWraper<bool>(Offsets.IsCompletePtr, Offsets.AchievementInstancePtr, achievementId);
             }
 
             return done;

--- a/Helpers/ActionHelper.cs
+++ b/Helpers/ActionHelper.cs
@@ -8,6 +8,7 @@ using LlamaLibrary.Enums;
 using LlamaLibrary.Extensions;
 using LlamaLibrary.Logging;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers
 {
@@ -39,7 +40,7 @@ namespace LlamaLibrary.Helpers
         public static bool UseAction(ff14bot.Enums.ActionType actionType, uint actionID, long targetID = 0xE000_0000, uint a4 = 0, uint a5 = 0, uint a6 = 0, uint a7 = 0)
         {
             Core.Memory.ClearCallCache();
-            var result = Core.Memory.CallInjected64<byte>(Offsets.DoAction, new object[8]
+            var result = Core.Memory.CallInjectedWraper<byte>(Offsets.DoAction, new object[8]
             {
                 Offsets.ActionManagerParam, //rcx
                 (uint)actionType, //rdx
@@ -64,7 +65,7 @@ namespace LlamaLibrary.Helpers
             }
 
             Core.Memory.ClearCallCache();
-            var result = Core.Memory.CallInjected64<byte>(Offsets.DoAction, new object[8]
+            var result = Core.Memory.CallInjectedWraper<byte>(Offsets.DoAction, new object[8]
             {
                 Offsets.ActionManagerParam, //rcx
                 (uint)ff14bot.Enums.ActionType.Spell, //rdx

--- a/Helpers/BeastTribeHelper.cs
+++ b/Helpers/BeastTribeHelper.cs
@@ -7,6 +7,7 @@ using ff14bot;
 using LlamaLibrary.Logging;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Structs;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers
 {
@@ -58,8 +59,8 @@ namespace LlamaLibrary.Helpers
 
             for (var i = 1; i <= Offsets.BeastTribeCount; i++)
             {
-                var result = Core.Memory.CallInjected64<IntPtr>(Offsets.GetBeastTribeExd, i);
-                var name = UppercaseFirst(Core.Memory.ReadStringUTF8(Core.Memory.CallInjected64<IntPtr>(Offsets.ResolveStringColumnIndirection, result)));
+                var result = Core.Memory.CallInjectedWraper<IntPtr>(Offsets.GetBeastTribeExd, i);
+                var name = UppercaseFirst(Core.Memory.ReadStringUTF8(Core.Memory.CallInjectedWraper<IntPtr>(Offsets.ResolveStringColumnIndirection, result)));
                 var tribe = Core.Memory.Read<BeastTribeExdTemp>(result);
 
                 tribes.Add(new BeastTribeExd(tribe, name));
@@ -110,13 +111,13 @@ namespace LlamaLibrary.Helpers
         /*
         public static string GetBeastTribeName(int index)
         {
-            var result = Core.Memory.CallInjected64<IntPtr>(Offsets.GetBeastTribeExd, index);
+            var result = Core.Memory.CallInjectedWraper<IntPtr>(Offsets.GetBeastTribeExd, index);
             return result != IntPtr.Zero ? Core.Memory.ReadString(result + 0x28, Encoding.UTF8) : "";
         }
 
         public static int GetBeastTribeMaxRank(int index)
         {
-            var result = Core.Memory.CallInjected64<IntPtr>(Offsets.GetBeastTribeExd, index);
+            var result = Core.Memory.CallInjectedWraper<IntPtr>(Offsets.GetBeastTribeExd, index);
             return result != IntPtr.Zero ? Core.Memory.Read<byte>(result + 0x22) : 0;
         }
         */

--- a/Helpers/BlueMageSpellBook.cs
+++ b/Helpers/BlueMageSpellBook.cs
@@ -7,6 +7,7 @@ using Buddy.Coroutines;
 using ff14bot;
 using LlamaLibrary.Logging;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers
 {
@@ -39,7 +40,7 @@ namespace LlamaLibrary.Helpers
 
         public static void SetSpell(int index, uint spellId)
         {
-            Core.Memory.CallInjected64<IntPtr>(Offsets.SetSpell, new object[3]
+            Core.Memory.CallInjectedWraper<IntPtr>(Offsets.SetSpell, new object[3]
             {
                 Offsets.ActionManager,
                 index,

--- a/Helpers/ChatBroadcaster.cs
+++ b/Helpers/ChatBroadcaster.cs
@@ -11,6 +11,7 @@ using ff14bot.Objects;
 using LlamaLibrary.ClientDataHelpers;
 using LlamaLibrary.Extensions;
 using LlamaLibrary.Memory;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers
 {
@@ -209,10 +210,10 @@ namespace LlamaLibrary.Helpers
                 allocatedMemory2.Write("dword4", 64);
                 allocatedMemory2.Write("dword8", array.Length + 1);
                 allocatedMemory2.Write("dwordC", 0);
-                Core.Memory.CallInjected64<int>(Offsets.ExecuteCommandInner,
-                                                UiManagerProxy.RaptureShellModule,
-                                                allocatedMemory2.Address,
-                                                UiManagerProxy.UIModule);
+                Core.Memory.CallInjectedWraper<int>(Offsets.ExecuteCommandInner,
+                                                    UiManagerProxy.RaptureShellModule,
+                                                    allocatedMemory2.Address,
+                                                    UiManagerProxy.UIModule);
             }
         }
     }

--- a/Helpers/CraftingHelper.cs
+++ b/Helpers/CraftingHelper.cs
@@ -7,6 +7,7 @@ using ff14bot.RemoteWindows;
 using LlamaLibrary.Logging;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Structs;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers
 {
@@ -50,7 +51,7 @@ namespace LlamaLibrary.Helpers
         {
             using (Core.Memory.TemporaryCacheState(false))
             {
-                return Core.Memory.CallInjected64<bool>(
+                return Core.Memory.CallInjectedWraper<bool>(
                     Offsets.HasCraftedRecipe,
                     recipeId);
             }
@@ -89,7 +90,7 @@ namespace LlamaLibrary.Helpers
 
         public static bool IsSecretRecipeBookUnlocked(uint key)
         {
-            return Core.Memory.CallInjected64<byte>(Memory.Offsets.IsSecretRecipeBookUnlocked, Memory.Offsets.PlayerState, key) == 1;
+            return Core.Memory.CallInjectedWraper<byte>(Memory.Offsets.IsSecretRecipeBookUnlocked, Memory.Offsets.PlayerState, key) == 1;
         }
 
         public static bool IsSecretRecipeBookUnlockedItem(uint key)
@@ -104,7 +105,7 @@ namespace LlamaLibrary.Helpers
 
         public static bool IsFolkloreBookUnlocked(uint key)
         {
-            return Core.Memory.CallInjected64<byte>(Memory.Offsets.IsFolkloreBookUnlocked, Memory.Offsets.PlayerState, key) == 1;
+            return Core.Memory.CallInjectedWraper<byte>(Memory.Offsets.IsFolkloreBookUnlocked, Memory.Offsets.PlayerState, key) == 1;
         }
 
         public static bool IsFolkloreBookUnlockedItem(uint key)

--- a/Helpers/CurrencyHelper.cs
+++ b/Helpers/CurrencyHelper.cs
@@ -5,6 +5,7 @@ using ff14bot;
 using ff14bot.Enums;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers
 {
@@ -50,10 +51,10 @@ namespace LlamaLibrary.Helpers
             uint result;
             lock (Core.Memory.Executor.AssemblyLock)
             {
-                result = Core.Memory.CallInjected64<uint>(
-                    Offsets.GetSpecialCurrencyItemId,
-                    SpecialCurrencyStorage,
-                    (byte)index);
+                result = Core.Memory.CallInjectedWraper<uint>(
+                                                              Offsets.GetSpecialCurrencyItemId,
+                                                              SpecialCurrencyStorage,
+                                                              (byte)index);
             }
 
             CurrencyCache.Add(index, result);
@@ -71,9 +72,9 @@ namespace LlamaLibrary.Helpers
             uint result;
             lock (Core.Memory.Executor.AssemblyLock)
             {
-                result = Core.Memory.CallInjected64<uint>(
-                    Offsets.GetTomeItemId,
-                    (int)index);
+                result = Core.Memory.CallInjectedWraper<uint>(
+                                                              Offsets.GetTomeItemId,
+                                                              (int)index);
             }
 
             TomeCache.Add(index, result);

--- a/Helpers/DirectorHelper.cs
+++ b/Helpers/DirectorHelper.cs
@@ -5,6 +5,8 @@ using ff14bot;
 using ff14bot.Directors;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
+
 
 namespace LlamaLibrary.Helpers
 {
@@ -35,7 +37,7 @@ namespace LlamaLibrary.Helpers
             if (ActiveDirectorAddress != CurrentDirector)
             {
                 CurrentDirector = ActiveDirectorAddress;
-                CurrentDirectorTodoArgs = Core.Memory.CallInjected64<IntPtr>(Offsets.GetTodoArgs, Offsets.ActiveDirector);
+                CurrentDirectorTodoArgs = Core.Memory.CallInjectedWraper<IntPtr>(Offsets.GetTodoArgs, Offsets.ActiveDirector);
             }
 
             if (CurrentDirector == IntPtr.Zero)

--- a/Helpers/GardenHelper.cs
+++ b/Helpers/GardenHelper.cs
@@ -18,6 +18,7 @@ using ff14bot.RemoteWindows;
 using LlamaLibrary.Logging;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.RemoteWindows;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers
 {
@@ -213,13 +214,13 @@ namespace LlamaLibrary.Helpers
 
         public static async Task Plant(BagSlot seeds, BagSlot soil)
         {
-            var result = Core.Memory.CallInjected64<IntPtr>(Offsets.PlantFunction, new object[3]
+            var result = Core.Memory.CallInjectedWraper<IntPtr>(Offsets.PlantFunction, new object[3]
             {
                 AgentHousingPlant.Instance.Pointer,
                 (uint)soil.BagId,
                 soil.Slot
             });
-            result = Core.Memory.CallInjected64<IntPtr>(Offsets.PlantFunction, new object[3]
+            result = Core.Memory.CallInjectedWraper<IntPtr>(Offsets.PlantFunction, new object[3]
             {
                 AgentHousingPlant.Instance.Pointer,
                 (uint)seeds.BagId,

--- a/Helpers/GeneralFunctions.cs
+++ b/Helpers/GeneralFunctions.cs
@@ -24,6 +24,7 @@ using LlamaLibrary.RemoteAgents;
 using LlamaLibrary.RemoteWindows;
 using LlamaLibrary.Retainers;
 using LlamaLibrary.Structs;
+using LlamaLibrary.Utilities;
 using Character = LlamaLibrary.RemoteWindows.Character;
 
 namespace LlamaLibrary.Helpers
@@ -721,7 +722,7 @@ namespace LlamaLibrary.Helpers
                     Log.Information($"OPEN: AgentId {AgentId} Offset {repairVendor.ToInt64():X} Func {repairWindow.ToInt64():X}");
                     lock (Core.Memory.Executor.AssemblyLock)
                     {
-                        Core.Memory.CallInjected64<IntPtr>(repairWindow,
+                        Core.Memory.CallInjectedWraper<IntPtr>(repairWindow,
                                                            ff14bot.Managers.AgentModule.GetAgentInterfaceById(AgentId).Pointer,
                                                            0,
                                                            0,
@@ -1703,7 +1704,7 @@ namespace LlamaLibrary.Helpers
 
         public static bool IsDutyUnlocked(uint dutyId)
         {
-            return DataManager.InstanceContentResults.TryGetValue(dutyId, out var instanceContentResult) && Core.Memory.CallInjected64<bool>(Offsets.IsInstanceContentUnlocked, instanceContentResult.Content);
+            return DataManager.InstanceContentResults.TryGetValue(dutyId, out var instanceContentResult) && Core.Memory.CallInjectedWraper<bool>(Offsets.IsInstanceContentUnlocked, instanceContentResult.Content);
         }
 
         public static async Task PassOnAllLoot()
@@ -1758,17 +1759,17 @@ namespace LlamaLibrary.Helpers
 
         public static uint GetDawnContentRowCount()
         {
-            return Core.Memory.CallInjected64<uint>(Offsets.GetDawnContentRowCount, new object[] { IntPtr.Zero });
+            return Core.Memory.CallInjectedWraper<uint>(Offsets.GetDawnContentRowCount, new object[] { IntPtr.Zero });
         }
 
         public static IntPtr GetDawnContentRow(uint index)
         {
-            return Core.Memory.CallInjected64<IntPtr>(Offsets.GetDawnContentRow, new object[] { index });
+            return Core.Memory.CallInjectedWraper<IntPtr>(Offsets.GetDawnContentRow, new object[] { index });
         }
 
         public static bool IsInstanceContentCompleted(uint instantContentId)
         {
-            return Core.Memory.CallInjected64<bool>(Offsets.IsInstanceContentCompleted, instantContentId);
+            return Core.Memory.CallInjectedWraper<bool>(Offsets.IsInstanceContentCompleted, instantContentId);
         }
 
         public static bool DalamudDetected()

--- a/Helpers/Housing/HousingHelper.cs
+++ b/Helpers/Housing/HousingHelper.cs
@@ -8,6 +8,7 @@ using LlamaLibrary.Enums;
 using LlamaLibrary.JsonObjects;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Structs;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers.Housing
 {
@@ -38,11 +39,11 @@ namespace LlamaLibrary.Helpers.Housing
 
         public static World _lastUpdateWorld;
 
-        public static long CurrentHouseId => Core.Memory.CallInjected64<long>(Offsets.GetCurrentHouseId, Core.Memory.Read<IntPtr>(Offsets.PositionInfoAddress));
+        public static long CurrentHouseId => Core.Memory.CallInjectedWraper<long>(Offsets.GetCurrentHouseId, Core.Memory.Read<IntPtr>(Offsets.PositionInfoAddress));
 
-        public static byte CurrentPlot => Core.Memory.CallInjected64<byte>(Offsets.GetCurrentPlot, Core.Memory.Read<IntPtr>(Offsets.PositionInfoAddress));
+        public static byte CurrentPlot => Core.Memory.CallInjectedWraper<byte>(Offsets.GetCurrentPlot, Core.Memory.Read<IntPtr>(Offsets.PositionInfoAddress));
 
-        public static byte CurrentWard => Core.Memory.CallInjected64<byte>(Offsets.GetCurrentWard, Core.Memory.Read<IntPtr>(Offsets.PositionInfoAddress));
+        public static byte CurrentWard => Core.Memory.CallInjectedWraper<byte>(Offsets.GetCurrentWard, Core.Memory.Read<IntPtr>(Offsets.PositionInfoAddress));
 
         private static ResidenceInfo[] _residences;
         public static IntPtr HousingInstance => Core.Memory.Read<IntPtr>(Offsets.PositionInfoAddress);

--- a/Helpers/Housing/ResidentialHousingManager.cs
+++ b/Helpers/Housing/ResidentialHousingManager.cs
@@ -5,6 +5,7 @@ using ff14bot;
 using LlamaLibrary.Enums;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Structs;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers.Housing;
 
@@ -25,12 +26,12 @@ public class ResidentialHousingManager
 
     public static long GetResidentialObject(int index, uint subIndex = 0xFFFFFFFF)
     {
-        return Core.Memory.CallInjected64<long>(Offsets.GetResidentObject, index, subIndex);
+        return Core.Memory.CallInjectedWraper<long>(Offsets.GetResidentObject, index, subIndex);
     }
 
     public static bool CheckValid(long index)
     {
-        return Core.Memory.CallInjected64<bool>(Offsets.CheckValid, index);
+        return Core.Memory.CallInjectedWraper<bool>(Offsets.CheckValid, index);
     }
 
     public static IEnumerable<ResidenceInfo> GetResidences()

--- a/Helpers/HuntHelper.cs
+++ b/Helpers/HuntHelper.cs
@@ -16,6 +16,7 @@ using LlamaLibrary.Logging;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.RemoteWindows;
 using LlamaLibrary.Structs;
+using LlamaLibrary.Utilities;
 using Newtonsoft.Json;
 
 namespace LlamaLibrary.Helpers
@@ -397,17 +398,17 @@ namespace LlamaLibrary.Helpers
 
         public static MobHuntTarget GetMobHuntTarget(int mob)
         {
-            return Core.Memory.Read<MobHuntTarget>(Core.Memory.CallInjected64<IntPtr>(Offsets.Client__ExdData__getMobHuntTarget, (uint)mob));
+            return Core.Memory.Read<MobHuntTarget>(Core.Memory.CallInjectedWraper<IntPtr>(Offsets.Client__ExdData__getMobHuntTarget, (uint)mob));
         }
 
         public static MobHuntOrderType GetMobHuntOrderType(int typeKey)
         {
-            return Core.Memory.Read<MobHuntOrderType>(Core.Memory.CallInjected64<IntPtr>(Offsets.Client__ExdData__getMobHuntOrderType, (uint)typeKey));
+            return Core.Memory.Read<MobHuntOrderType>(Core.Memory.CallInjectedWraper<IntPtr>(Offsets.Client__ExdData__getMobHuntOrderType, (uint)typeKey));
         }
 
         public static bool OrderTypeUnlocked(int typeKey)
         {
-            var unlockState = Core.Memory.CallInjected64<byte>(Offsets.CheckMobBoardUnlocked,
+            var unlockState = Core.Memory.CallInjectedWraper<byte>(Offsets.CheckMobBoardUnlocked,
                                                                new object[2]
                                                                {
                                                                    Offsets.HuntData,
@@ -427,12 +428,12 @@ namespace LlamaLibrary.Helpers
         public static MobHuntOrder GetMobHuntOrder(uint typeKey, uint mobIndex)
         {
             Core.Memory.ClearCallCache();
-            return Core.Memory.Read<MobHuntOrder>(Core.Memory.CallInjected64<IntPtr>(Offsets.Client__ExdData__getMobHuntOrder, typeKey, mobIndex));
+            return Core.Memory.Read<MobHuntOrder>(Core.Memory.CallInjectedWraper<IntPtr>(Offsets.Client__ExdData__getMobHuntOrder, typeKey, mobIndex));
         }
 
         public static void DiscardMobHuntType(uint typekey)
         {
-            Core.Memory.CallInjected64<IntPtr>(Offsets.YeetHuntOrderType,
+            Core.Memory.CallInjectedWraper<IntPtr>(Offsets.YeetHuntOrderType,
                                                Offsets.HuntData,
                                                typekey);
         }

--- a/Helpers/NPC/NpcHelper.cs
+++ b/Helpers/NPC/NpcHelper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using ff14bot;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers.NPC
 {
@@ -90,7 +91,7 @@ namespace LlamaLibrary.Helpers.NPC
                 return value;
             }
 
-            var ptr = Core.Memory.CallInjected64<IntPtr>(Offsets.GetENpcResident, npcId);
+            var ptr = Core.Memory.CallInjectedWraper<IntPtr>(Offsets.GetENpcResident, npcId);
 
             if (ptr == IntPtr.Zero)
             {

--- a/Helpers/ScreenshotHelper.cs
+++ b/Helpers/ScreenshotHelper.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Buddy.Coroutines;
 using ff14bot;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers
 {
@@ -49,7 +50,7 @@ namespace LlamaLibrary.Helpers
 
         public static bool CallScreenshotRaw()
         {
-            return Core.Memory.CallInjected64<bool>(
+            return Core.Memory.CallInjectedWraper<bool>(
                 Offsets.ScreenshotFunc,
                 ScreenshotStruct,
                 Offsets.CallbackFunction,

--- a/Helpers/TeleportHelper.cs
+++ b/Helpers/TeleportHelper.cs
@@ -11,6 +11,7 @@ using LlamaLibrary.Enums;
 using LlamaLibrary.Logging;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Structs;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers;
 
@@ -52,7 +53,7 @@ public static class TeleportHelper
 
     public static void CallUpdate()
     {
-        Core.Memory.CallInjected64<IntPtr>(Offsets.UpdatePlayerAetheryteList, Memory.Offsets.UIStateTelepo, 0);
+        Core.Memory.CallInjectedWraper<IntPtr>(Offsets.UpdatePlayerAetheryteList, Memory.Offsets.UIStateTelepo, 0);
     }
 
     public static async Task<bool> TeleportToApartment()
@@ -218,7 +219,7 @@ public static class TeleportHelper
 
     public static bool TeleportUsingTicket(uint ae, byte subIndex = 0)
     {
-        return Core.Memory.CallInjected64<byte>(Offsets.TeleportWithSettings, Offsets.Telepo, ae, subIndex) != 0;
+        return Core.Memory.CallInjectedWraper<byte>(Offsets.TeleportWithSettings, Offsets.Telepo, ae, subIndex) != 0;
     }
 
     public static async Task<bool> TeleportWithTicket(AetheryteResult aetheryte)

--- a/Helpers/Timers.cs
+++ b/Helpers/Timers.cs
@@ -5,6 +5,7 @@ using ff14bot.Helpers;
 using LlamaLibrary.Logging;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Structs;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers;
 
@@ -12,7 +13,7 @@ public static class Timers
 {
     private static readonly LLogger Log = new("TimersHelper", Colors.Peru);
 
-    private static readonly FrameCachedValue<ulong> CurrentTimeCachedValue = new(() => Core.Memory.CallInjected64<ulong>(Offsets.GetCurrentTime, 0));
+    private static readonly FrameCachedValue<ulong> CurrentTimeCachedValue = new(() => Core.Memory.CallInjectedWraper<ulong>(Offsets.GetCurrentTime, 0));
 
     // ReSharper disable once MemberCanBePrivate.Global
     internal static class Offsets
@@ -61,7 +62,7 @@ public static class Timers
 
     public static CycleTime GetCycleRow(int index)
     {
-        var cyclePtr = Core.Memory.CallInjected64<IntPtr>(Offsets.GetCycleExd, index);
+        var cyclePtr = Core.Memory.CallInjectedWraper<IntPtr>(Offsets.GetCycleExd, index);
 
         return cyclePtr != IntPtr.Zero ? Core.Memory.Read<CycleTime>(cyclePtr) : default;
     }

--- a/Helpers/UIInputHelper.cs
+++ b/Helpers/UIInputHelper.cs
@@ -4,6 +4,7 @@ using System.Windows.Media;
 using ff14bot;
 using LlamaLibrary.Logging;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers
 {
@@ -78,7 +79,7 @@ namespace LlamaLibrary.Helpers
 
         public static void StringCtor(IntPtr ptr)
         {
-            Core.Memory.CallInjected64<int>(Offsets.Utf8StringCtor, ptr);
+            Core.Memory.CallInjectedWraper<int>(Offsets.Utf8StringCtor, ptr);
         }
 
         public static void StringCtorFromSequence(IntPtr ptr, string input, uint length)
@@ -89,7 +90,7 @@ namespace LlamaLibrary.Helpers
                 Core.Memory.CreateAllocatedMemory(array.Length + 30);
             allocatedMemory.AllocateOfChunk("start", array.Length);
             allocatedMemory.WriteBytes("start", array);
-            Core.Memory.CallInjected64<int>(Offsets.Utf8StringFromSequenceCtor, ptr, allocatedMemory.Address, length);
+            Core.Memory.CallInjectedWraper<int>(Offsets.Utf8StringFromSequenceCtor, ptr, allocatedMemory.Address, length);
         }
 
         public static void SetString(IntPtr ptr, string input)
@@ -101,7 +102,7 @@ namespace LlamaLibrary.Helpers
             allocatedMemory.AllocateOfChunk("start", array.Length);
             allocatedMemory.WriteBytes("start", array);
 
-            Core.Memory.CallInjected64<int>(Offsets.Utf8SetString, ptr, allocatedMemory.Address);
+            Core.Memory.CallInjectedWraper<int>(Offsets.Utf8SetString, ptr, allocatedMemory.Address);
         }
 
         public static void SendInput(string input)
@@ -112,7 +113,7 @@ namespace LlamaLibrary.Helpers
             Log.Verbose($"Constructed string at {seStringAlloc.Address}");
             SetString(seStringAlloc.Address, input);
             Log.Verbose($"Set string at {seStringAlloc.Address}");
-            Core.Memory.CallInjected64<int>(Offsets.SendStringToFocus, GetInputTextPtr, seStringAlloc.Address, 0);
+            Core.Memory.CallInjectedWraper<int>(Offsets.SendStringToFocus, GetInputTextPtr, seStringAlloc.Address, 0);
             Log.Verbose($"Sent string to focus at {GetInputTextPtr}");
         }
 
@@ -120,7 +121,7 @@ namespace LlamaLibrary.Helpers
         {
             using var seStringAlloc = Core.Memory.CreateAllocatedMemory(0x68);
             StringCtorFromSequence(seStringAlloc.Address, "\0", 0xFFFFFFFF);
-            Core.Memory.CallInjected64<int>(Offsets.SendStringToFocus, GetInputTextPtr, seStringAlloc.Address, 1);
+            Core.Memory.CallInjectedWraper<int>(Offsets.SendStringToFocus, GetInputTextPtr, seStringAlloc.Address, 1);
         }
     }
 }

--- a/Helpers/UIState.cs
+++ b/Helpers/UIState.cs
@@ -7,6 +7,7 @@ using ff14bot.Managers;
 using LlamaLibrary.Logging;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.RetainerItemFinder;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers;
 
@@ -46,15 +47,15 @@ public static class UIState
 
     public static int ItemActionOffset => Offsets.ItemActionOffset;
 
-    public static bool CardUnlocked(int id) => Core.Memory.CallInjected64<bool>(Offsets.CardUnlocked, Offsets.Instance, id);
+    public static bool CardUnlocked(int id) => Core.Memory.CallInjectedWraper<bool>(Offsets.CardUnlocked, Offsets.Instance, id);
 
-    public static bool EmoteUnlocked(int id) => Core.Memory.CallInjected64<bool>(Offsets.EmoteUnlocked, Offsets.Instance, id);
+    public static bool EmoteUnlocked(int id) => Core.Memory.CallInjectedWraper<bool>(Offsets.EmoteUnlocked, Offsets.Instance, id);
 
     public static byte[] MinionArray => Core.Memory.ReadBytes(Offsets.MinionArray, 0x50);
 
     public static bool MinionUnlocked(int id) => ((1 << (id & 7)) & MinionArray[id >> 3]) > 0;
 
-    public static IntPtr GetItemExdData(uint id) => Core.Memory.CallInjected64<IntPtr>(Offsets.ExdGetItem, id);
+    public static IntPtr GetItemExdData(uint id) => Core.Memory.CallInjectedWraper<IntPtr>(Offsets.ExdGetItem, id);
 
     public static bool IsItemActionUnlocked(uint id)
     {
@@ -84,7 +85,7 @@ public static class UIState
             using (var newStruct = Core.Memory.CreateAllocatedMemory(0x98))
             {
                 newStruct.Write(Offsets.ItemActionOffset, (ushort)item.ItemAction);
-                return Core.Memory.CallInjected64<int>(Offsets.IsItemActionUnlocked, Offsets.Instance, newStruct.Address) == 1;
+                return Core.Memory.CallInjectedWraper<int>(Offsets.IsItemActionUnlocked, Offsets.Instance, newStruct.Address) == 1;
             }
         }
 
@@ -93,7 +94,7 @@ public static class UIState
             throw new Exception("Item not found in exd");
         }
 
-        return Core.Memory.CallInjected64<int>(Offsets.IsItemActionUnlocked, Offsets.Instance, itemPtr) == 1;
+        return Core.Memory.CallInjectedWraper<int>(Offsets.IsItemActionUnlocked, Offsets.Instance, itemPtr) == 1;
     }
 
     public static bool CanUnlockItem(uint itemId)

--- a/Helpers/WorldHelper.cs
+++ b/Helpers/WorldHelper.cs
@@ -6,6 +6,7 @@ using ff14bot.Enums;
 using ff14bot.Managers;
 using LlamaLibrary.Enums;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Helpers
 {
@@ -54,7 +55,7 @@ namespace LlamaLibrary.Helpers
         {
             get
             {
-                var ptr = Core.Memory.CallInjected64<IntPtr>(Offsets.GetPlaceName, WorldManager.SubZoneId);
+                var ptr = Core.Memory.CallInjectedWraper<IntPtr>(Offsets.GetPlaceName, WorldManager.SubZoneId);
                 return Core.Memory.ReadStringUTF8(ptr + 24);
             }
         }

--- a/Managers/PointMenuManager.cs
+++ b/Managers/PointMenuManager.cs
@@ -32,7 +32,7 @@ namespace LlamaLibrary.Managers
             //{
             //    var func = Core.Memory.Read<IntPtr>(Core.Memory.Read<IntPtr>(Window.Pointer) + (8 * 2));
 
-            //    Core.Memory.CallInjected64<IntPtr>(func, Window.Pointer, 25UL, position, mem.Address);
+            //    Core.Memory.CallInjectedWraper<IntPtr>(func, Window.Pointer, 25UL, position, mem.Address);
             //}
         }
     }

--- a/Managers/RelicBookManager.cs
+++ b/Managers/RelicBookManager.cs
@@ -7,6 +7,7 @@ using ff14bot.Enums;
 using ff14bot.Managers;
 using LlamaLibrary.Helpers;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Managers
 
@@ -120,7 +121,7 @@ namespace LlamaLibrary.Managers
 
         public static byte GetNumOfRelicNoteCompleted(uint relicId, RelicBookType relicBookType)
         {
-            return Core.Memory.CallInjected64<byte>(Offsets.GetNumOfRelicNoteCompleted, Offsets.UIRelicNote, relicId, (byte)relicBookType);
+            return Core.Memory.CallInjectedWraper<byte>(Offsets.GetNumOfRelicNoteCompleted, Offsets.UIRelicNote, relicId, (byte)relicBookType);
         }
 
         public static byte NumOfFireCompleted(uint relicId)

--- a/RemoteAgents/AgentAWGrowthFragTrade.cs
+++ b/RemoteAgents/AgentAWGrowthFragTrade.cs
@@ -10,6 +10,7 @@ using LlamaLibrary.Logging;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.RemoteWindows;
 using LlamaLibrary.Structs;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.RemoteAgents
 {
@@ -47,7 +48,7 @@ namespace LlamaLibrary.RemoteAgents
 
         public void Buy(int index, int qty)
         {
-            Core.Memory.CallInjected64<int>(Offsets.BuyFunction, Pointer, index, qty);
+            Core.Memory.CallInjectedWraper<int>(Offsets.BuyFunction, Pointer, index, qty);
         }
 
         public static async Task<bool> BuyCrystalSand(uint itemToSpend, int qty, bool buyAnyAmount = false)

--- a/RemoteAgents/AgentBankaCraftworksSupply.cs
+++ b/RemoteAgents/AgentBankaCraftworksSupply.cs
@@ -2,6 +2,7 @@
 using ff14bot;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.RemoteAgents;
 
@@ -37,7 +38,7 @@ public class AgentBankaCraftworksSupply : AgentInterface<AgentBankaCraftworksSup
         var instance = Pointer + Offsets.PointerOffset;
         lock (Core.Memory.Executor.AssemblyLock)
         {
-            Core.Memory.CallInjected64<uint>(Core.Memory.Read<IntPtr>(Core.Memory.Read<IntPtr>(instance)),
+            Core.Memory.CallInjectedWraper<uint>(Core.Memory.Read<IntPtr>(Core.Memory.Read<IntPtr>(instance)),
                                                                       instance,
                                                                       slot.Slot,
                                                                       (int)slot.BagId);

--- a/RemoteAgents/AgentFreeCompanyChest.cs
+++ b/RemoteAgents/AgentFreeCompanyChest.cs
@@ -5,6 +5,7 @@ using ff14bot;
 using ff14bot.Enums;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.RemoteAgents
 {
@@ -67,7 +68,7 @@ namespace LlamaLibrary.RemoteAgents
         {
             lock (Core.Memory.Executor.AssemblyLock)
             {
-                return Core.Memory.CallInjected64<byte>(Offsets.BagRequestCall, Memory.Offsets.g_InventoryManager, bagId);
+                return Core.Memory.CallInjectedWraper<byte>(Offsets.BagRequestCall, Memory.Offsets.g_InventoryManager, bagId);
             }
         }
 

--- a/RemoteAgents/AgentGrandCompanyExchange.cs
+++ b/RemoteAgents/AgentGrandCompanyExchange.cs
@@ -3,6 +3,7 @@ using ff14bot;
 using ff14bot.Managers;
 using LlamaLibrary.Helpers;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.RemoteAgents
 {
@@ -40,7 +41,7 @@ namespace LlamaLibrary.RemoteAgents
 
         public void BuyItem(uint index, int qty)
         {
-            Core.Memory.CallInjected64<IntPtr>(Offsets.BuyItem, GrandCompanyShop.ActiveShopPtr, 0, index, qty);
+            Core.Memory.CallInjectedWraper<IntPtr>(Offsets.BuyItem, GrandCompanyShop.ActiveShopPtr, 0, index, qty);
         }
     }
 }

--- a/RemoteAgents/AgentHandIn.cs
+++ b/RemoteAgents/AgentHandIn.cs
@@ -2,6 +2,7 @@
 using ff14bot;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.RemoteAgents
 {
@@ -26,11 +27,11 @@ namespace LlamaLibrary.RemoteAgents
         {
             lock (Core.Memory.Executor.AssemblyLock)
             {
-                Core.Memory.CallInjected64<uint>(
-                    Offsets.HandInFunc,
-                    Pointer + Offsets.HandinParmOffset,
-                    slot.Slot,
-                    (int)slot.BagId);
+                Core.Memory.CallInjectedWraper<uint>(
+                                                     Offsets.HandInFunc,
+                                                     Pointer + Offsets.HandinParmOffset,
+                                                     slot.Slot,
+                                                     (int)slot.BagId);
             }
         }
     }

--- a/RemoteAgents/AgentMinionNoteBook.cs
+++ b/RemoteAgents/AgentMinionNoteBook.cs
@@ -4,6 +4,7 @@ using System.Text;
 using ff14bot;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.RemoteAgents
 {
@@ -40,7 +41,7 @@ namespace LlamaLibrary.RemoteAgents
 
         public static string GetMinionName(int index)
         {
-            var result = Core.Memory.CallInjected64<IntPtr>(Offsets.GetCompanion, index);
+            var result = Core.Memory.CallInjectedWraper<IntPtr>(Offsets.GetCompanion, index);
             return result != IntPtr.Zero ? Core.Memory.ReadString(result + 0x30, Encoding.UTF8) : "";
         }
     }

--- a/RemoteAgents/AgentSatisfactionSupply.cs
+++ b/RemoteAgents/AgentSatisfactionSupply.cs
@@ -6,6 +6,7 @@ using ff14bot;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.RemoteWindows;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.RemoteAgents
 {
@@ -103,7 +104,7 @@ namespace LlamaLibrary.RemoteAgents
                 await Coroutine.Wait(5000, () => !SatisfactionSupply.Instance.IsOpen);
             }
 
-            Core.Memory.CallInjected64<IntPtr>(Offsets.OpenWindow,
+            Core.Memory.CallInjectedWraper<IntPtr>(Offsets.OpenWindow,
                                                Pointer,
                                                0U,
                                                npc,

--- a/RemoteAgents/AgentSharlayanCraftworksSupply.cs
+++ b/RemoteAgents/AgentSharlayanCraftworksSupply.cs
@@ -2,6 +2,7 @@
 using ff14bot;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.RemoteAgents;
 
@@ -37,7 +38,7 @@ public class AgentSharlayanCraftworksSupply : AgentInterface<AgentSharlayanCraft
     {
         lock (Core.Memory.Executor.AssemblyLock)
         {
-            Core.Memory.CallInjected64<uint>(
+            Core.Memory.CallInjectedWraper<uint>(
                                              Offsets.HandIn,
                                              Pointer + Offsets.PointerOffset,
                                              slot.Slot,
@@ -49,7 +50,7 @@ public class AgentSharlayanCraftworksSupply : AgentInterface<AgentSharlayanCraft
         var instance = Pointer + Offsets.PointerOffset;
         lock (Core.Memory.Executor.AssemblyLock)
         {
-            Core.Memory.CallInjected64<uint>(Core.Memory.Read<IntPtr>(Core.Memory.Read<IntPtr>(instance)),
+            Core.Memory.CallInjectedWraper<uint>(Core.Memory.Read<IntPtr>(Core.Memory.Read<IntPtr>(instance)),
                                              instance,
                                              slot.Slot,
                                              (int)slot.BagId);

--- a/RemoteAgents/AgentTripleTriadCoinExchange.cs
+++ b/RemoteAgents/AgentTripleTriadCoinExchange.cs
@@ -48,7 +48,7 @@ public class AgentTripleTriadCoinExchange : AgentInterface<AgentTripleTriadCoinE
         set => Core.Memory.Write(Pointer + Offsets.SelectedCardIndex, value);
     }
 
-    //private void OpenSellWindowRaw(IntPtr cardPTr) => Core.Memory.CallInjected64<IntPtr>(Offsets.OpenSellWindow, Pointer, cardPTr);
+    //private void OpenSellWindowRaw(IntPtr cardPTr) => Core.Memory.CallInjectedWraper<IntPtr>(Offsets.OpenSellWindow, Pointer, cardPTr);
 
     public TripleTriadCoinExchangeCard[] Cards
     {

--- a/RemoteWindows/Atk/AtkClientFunctions.cs
+++ b/RemoteWindows/Atk/AtkClientFunctions.cs
@@ -2,6 +2,7 @@
 using ff14bot;
 using ff14bot.Managers;
 using LlamaLibrary.Memory;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.RemoteWindows.Atk;
 
@@ -73,7 +74,7 @@ internal static class AtkClientFunctions
 
         lock (Core.Memory.GetLock())
         {
-            Core.Memory.CallInjected64<IntPtr>(Offsets.SendAction, windowPtr, param.Length / 2, allocated.Address, (byte)(updateState ? 1 : 0));
+            Core.Memory.CallInjectedWraper<IntPtr>(Offsets.SendAction, windowPtr, param.Length / 2, allocated.Address, (byte)(updateState ? 1 : 0));
         }
     }
 
@@ -85,6 +86,6 @@ internal static class AtkClientFunctions
             return;
         }
 
-        Core.Memory.CallInjected64<IntPtr>(Offsets.DialogueOkay, window.Pointer, 0x19);
+        Core.Memory.CallInjectedWraper<IntPtr>(Offsets.DialogueOkay, window.Pointer, 0x19);
     }
 }

--- a/RemoteWindows/GrandCompanySupplyList.cs
+++ b/RemoteWindows/GrandCompanySupplyList.cs
@@ -8,6 +8,7 @@ using ff14bot.Enums;
 using ff14bot.RemoteWindows;
 using LlamaLibrary.Helpers;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.RemoteWindows
 {
@@ -109,7 +110,7 @@ namespace LlamaLibrary.RemoteWindows
             SendAction(2, 3, 5, 3, filter);
             if (WindowByName != null)
             {
-                Core.Memory.CallInjected64<IntPtr>(Offsets.SetFilter, WindowByName.Pointer, (int)filter);
+                Core.Memory.CallInjectedWraper<IntPtr>(Offsets.SetFilter, WindowByName.Pointer, (int)filter);
             }
         }
 

--- a/RemoteWindows/HWDLottery.cs
+++ b/RemoteWindows/HWDLottery.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Buddy.Coroutines;
 using ff14bot;
 using LlamaLibrary.Memory.Attributes;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.RemoteWindows
 {
@@ -35,7 +36,7 @@ namespace LlamaLibrary.RemoteWindows
 
                 if (agent != null)
                 {
-                    Core.Memory.CallInjected64<uint>(Offsets.KupoFunction, new object[2]
+                    Core.Memory.CallInjectedWraper<uint>(Offsets.KupoFunction, new object[2]
                     {
                         agent.Pointer,
                         1U

--- a/RemoteWindows/RetainerHistory.cs
+++ b/RemoteWindows/RetainerHistory.cs
@@ -11,6 +11,7 @@ using LlamaLibrary.JsonObjects;
 using LlamaLibrary.Logging;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Retainers;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.RemoteWindows
 {
@@ -115,8 +116,8 @@ namespace LlamaLibrary.RemoteWindows
             get
             {
                 var func = Core.Memory.Read<IntPtr>(Core.Memory.Read<IntPtr>(UiManagerProxy.UIModule) + Offsets.GetSomethingModuleVtblFunction);
-                var subModule = Core.Memory.CallInjected64<IntPtr>(func, UiManagerProxy.UIModule);
-                var pointer = Core.Memory.CallInjected64<IntPtr>(Offsets.GetSubModule, subModule, Offsets.SubModule);
+                var subModule = Core.Memory.CallInjectedWraper<IntPtr>(func, UiManagerProxy.UIModule);
+                var pointer = Core.Memory.CallInjectedWraper<IntPtr>(Offsets.GetSubModule, subModule, Offsets.SubModule);
                 return pointer;
             }
         }
@@ -134,7 +135,7 @@ namespace LlamaLibrary.RemoteWindows
                 var name = fullRets.First(i => i.Unique == retainerId).Name;
                 Core.Memory.Write(HistoryCountLocation, 99);
                 Core.Memory.Write(retainerIdLocation, retainerId);
-                Core.Memory.CallInjected64<IntPtr>(Offsets.RequestSales, raptureStruct);
+                Core.Memory.CallInjectedWraper<IntPtr>(Offsets.RequestSales, raptureStruct);
                 if (await Coroutine.Wait(5000, () => Core.Memory.NoCacheRead<int>(HistoryCountLocation) != 99))
                 {
                     result.Add(retainerId, Sales.ToList());

--- a/RetainerItemFinder/ItemFinder.cs
+++ b/RetainerItemFinder/ItemFinder.cs
@@ -12,6 +12,7 @@ using LlamaLibrary.Logging;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.RemoteWindows;
 using LlamaLibrary.Retainers;
+using LlamaLibrary.Utilities;
 
 #pragma warning disable 649
 namespace LlamaLibrary.RetainerItemFinder
@@ -39,7 +40,7 @@ namespace LlamaLibrary.RetainerItemFinder
         static ItemFinder()
         {
             Framework = Core.Memory.Read<IntPtr>(Offsets.GFramework2);
-            var getUiModule = Core.Memory.CallInjected64<IntPtr>(Offsets.GetUiModule, Framework);
+            var getUiModule = Core.Memory.CallInjectedWraper<IntPtr>(Offsets.GetUiModule, Framework);
             var getRaptureItemFinder = getUiModule + Offsets.RaptureItemFinder;
 
             Pointer = getRaptureItemFinder;

--- a/Retainers/HelperFunctions.cs
+++ b/Retainers/HelperFunctions.cs
@@ -18,6 +18,7 @@ using LlamaLibrary.Memory;
 using LlamaLibrary.RemoteAgents;
 using LlamaLibrary.RemoteWindows;
 using LlamaLibrary.Structs;
+using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Retainers
 {
@@ -524,7 +525,7 @@ namespace LlamaLibrary.Retainers
         {
             lock (Core.Memory.Executor.AssemblyLock)
             {
-                return Core.Memory.CallInjected64<int>(Offsets.GetNumberOfRetainers,
+                return Core.Memory.CallInjectedWraper<int>(Offsets.GetNumberOfRetainers,
                                                        Offsets.RetainerData);
             }
         }
@@ -544,7 +545,7 @@ namespace LlamaLibrary.Retainers
         {
             lock (Core.Memory.Executor.AssemblyLock)
             {
-                Core.Memory.CallInjected64<IntPtr>(Offsets.ExecuteCommand,
+                Core.Memory.CallInjectedWraper<IntPtr>(Offsets.ExecuteCommand,
                                                    (uint)Offsets.RetainerNetworkPacket,
                                                    0U,
                                                    0U,

--- a/Utilities/CallSafety.cs
+++ b/Utilities/CallSafety.cs
@@ -1,0 +1,33 @@
+//#define LogCall
+
+using System;
+using System.Diagnostics;
+using ff14bot;
+using GreyMagic;
+
+namespace LlamaLibrary.Utilities;
+
+public static class CallSafety
+{
+    public static T CallInjectedWraper<T>(this ExternalProcessMemory memory,IntPtr address, params object[] args) where T : struct
+    {
+
+#if LogCall
+        var methodInfo = new StackTrace().GetFrame(1).GetMethod();
+        var className = methodInfo.ReflectedType.Name;
+
+        ff14bot.Helpers.Logging.Write("Calling from {0} {1}", className, methodInfo.Name);
+#endif
+
+        if (address < memory.ImageBase)
+        {
+            throw new Exception("Address is not in the game process");
+        }
+
+        lock (memory.Executor.AssemblyLock)
+        {
+            return memory.CallInjected64<T>(address, args);
+        }
+    }
+
+}


### PR DESCRIPTION
--Prevents calling functions who address is less then the games base address, this prevents crashes when a offset returns 0 
--Allows logging when a function is called, this makes it easier to identify when a function call is crashing the client