### PR TITLE
📝 Scribe: Add XML documentation for core botbase and plugin interfaces

### DIFF
--- a/ExportedAPI.cs
+++ b/ExportedAPI.cs
@@ -1,7 +1,14 @@
-﻿namespace LlamaLibrary
+namespace LlamaLibrary
 {
+    /// <summary>
+    /// Defines a contract for an API exported by a botbase or plugin, allowing other components to interact with it.
+    /// </summary>
     public interface IExportedApi
     {
+        /// <summary>
+        /// Initializes the exported API.
+        /// </summary>
+        /// <returns><see langword="true"/> if initialization was successful; otherwise <see langword="false"/>.</returns>
         bool Init();
     }
 }

--- a/ICompiledAPIBotbase.cs
+++ b/ICompiledAPIBotbase.cs
@@ -1,7 +1,13 @@
-﻿namespace LlamaLibrary
+namespace LlamaLibrary
 {
+    /// <summary>
+    /// Defines a botbase contract that exposes an <see cref="IExportedApi"/> for external interaction.
+    /// </summary>
     public interface ICompiledAPIBotbase : ICompiledBotbase
     {
+        /// <summary>
+        /// Gets the exported API instance provided by this botbase.
+        /// </summary>
         IExportedApi Api { get; }
     }
 }

--- a/ICompiledAsyncBotbase.cs
+++ b/ICompiledAsyncBotbase.cs
@@ -1,21 +1,71 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using ff14bot.Behavior;
 
 namespace LlamaLibrary
 {
+    /// <summary>
+    /// Defines the contract for an asynchronous botbase compiled and loaded by LlamaLibrary.
+    /// Uses <see cref="Task"/>-based logic instead of <see cref="TreeSharp.Composite"/>.
+    /// </summary>
     public interface ICompiledAsyncBotbase
     {
+        /// <summary>
+        /// Gets the display name of the botbase as shown in the RebornBuddy bot selection dropdown.
+        /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// Gets the pulse flags that define which RebornBuddy engine features (e.g., targeting, movement)
+        /// are active while this botbase is running.
+        /// </summary>
         PulseFlags PulseFlags { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this botbase requires a profile (e.g., an XML quest profile) to function.
+        /// </summary>
         bool RequiresProfile { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this botbase provides a configuration or settings button in the RebornBuddy UI.
+        /// </summary>
         bool WantButton { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the botbase is autonomous, meaning it manages its own navigation and task logic.
+        /// </summary>
         bool IsAutonomous { get; }
 
+        /// <summary>
+        /// The main asynchronous execution loop of the botbase.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task AsyncRoot();
+
+        /// <summary>
+        /// Called by RebornBuddy when the user starts the bot.
+        /// </summary>
         void Start();
+
+        /// <summary>
+        /// Called by RebornBuddy when the user stops the bot.
+        /// </summary>
         void Stop();
+
+        /// <summary>
+        /// Called when the user clicks the botbase's button in the RebornBuddy UI.
+        /// Only invoked if <see cref="WantButton"/> is <see langword="true"/>.
+        /// </summary>
         void OnButtonPress();
+
+        /// <summary>
+        /// Passes external configuration parameters to the botbase.
+        /// </summary>
+        /// <param name="param">A string containing configuration or command parameters.</param>
         void SetParameters(string param);
+
+        /// <summary>
+        /// Called when the botbase is first loaded or initialized by the assembly loader.
+        /// </summary>
         void Initialize();
     }
 }

--- a/ICompiledBotbase.cs
+++ b/ICompiledBotbase.cs
@@ -1,29 +1,91 @@
-﻿using System;
+using System;
 using ff14bot.Behavior;
 using TreeSharp;
 
 namespace LlamaLibrary
 {
+    /// <summary>
+    /// Defines the basic contract for a botbase compiled and loaded by LlamaLibrary.
+    /// </summary>
     public interface ICompiledBotbase
     {
+        /// <summary>
+        /// Gets the display name of the botbase as shown in the RebornBuddy bot selection dropdown.
+        /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// Gets the pulse flags that define which RebornBuddy engine features (e.g., targeting, movement)
+        /// are active while this botbase is running.
+        /// </summary>
         PulseFlags PulseFlags { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this botbase requires a profile (e.g., an XML quest profile) to function.
+        /// </summary>
         bool RequiresProfile { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this botbase provides a configuration or settings button in the RebornBuddy UI.
+        /// </summary>
         bool WantButton { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the botbase is autonomous, meaning it manages its own navigation and task logic.
+        /// </summary>
         bool IsAutonomous { get; }
 
+        /// <summary>
+        /// Returns the <see cref="Composite"/> logic tree that RebornBuddy will execute while the bot is running.
+        /// </summary>
+        /// <returns>A TreeSharp composite representing the bot's behavior.</returns>
         Composite GetRoot();
+
+        /// <summary>
+        /// Called by RebornBuddy when the user starts the bot.
+        /// </summary>
         void Start();
+
+        /// <summary>
+        /// Called by RebornBuddy when the user stops the bot.
+        /// </summary>
         void Stop();
+
+        /// <summary>
+        /// Called when the user clicks the botbase's button in the RebornBuddy UI.
+        /// Only invoked if <see cref="WantButton"/> is <see langword="true"/>.
+        /// </summary>
         void OnButtonPress();
+
+        /// <summary>
+        /// Called when the botbase is first loaded or initialized by the assembly loader.
+        /// </summary>
         void Initialize();
     }
 
+    /// <summary>
+    /// An extended version of <see cref="ICompiledBotbase"/> that includes additional lifecycle methods and metadata.
+    /// </summary>
     public interface ICompiledBotbaseFull : ICompiledBotbase, IDisposable
     {
+        /// <summary>
+        /// Gets the version string of the botbase.
+        /// </summary>
         string Version { get; }
+
+        /// <summary>
+        /// Called on every RebornBuddy pulse (tick) while this botbase is active.
+        /// </summary>
         void Pulse();
+
+        /// <summary>
+        /// Called when RebornBuddy is shutting down or when the botbase is being unloaded.
+        /// </summary>
         void OnShutdown();
+
+        /// <summary>
+        /// Gets the English display name of the botbase, useful for logging or internationalization.
+        /// </summary>
         string EnglishName { get; }
     }
 }

--- a/ICompiledPlugin.cs
+++ b/ICompiledPlugin.cs
@@ -1,8 +1,14 @@
-﻿using ff14bot.Interfaces;
+using ff14bot.Interfaces;
 
 namespace LlamaLibrary;
 
+/// <summary>
+/// Defines a contract for a RebornBuddy plugin that exposes an <see cref="IExportedApi"/>.
+/// </summary>
 public interface ICompiledPlugin : IBotPlugin
 {
+    /// <summary>
+    /// Gets the exported API instance provided by this plugin.
+    /// </summary>
     IExportedApi Api { get; }
 }

--- a/IDisposableCompiledAsyncBotbase.cs
+++ b/IDisposableCompiledAsyncBotbase.cs
@@ -1,14 +1,30 @@
-﻿using System;
+using System;
 
 namespace LlamaLibrary;
 
+/// <summary>
+/// Defines an extended contract for an asynchronous botbase that is also <see cref="IDisposable"/>.
+/// Includes additional metadata and lifecycle methods for pulse and shutdown.
+/// </summary>
 public interface IDisposableCompiledAsyncBotbase : ICompiledAsyncBotbase, IDisposable
 {
+    /// <summary>
+    /// Gets the English display name of the botbase.
+    /// </summary>
     string EnglishName { get; }
 
+    /// <summary>
+    /// Gets the version of the botbase.
+    /// </summary>
     Version Version { get; }
 
+    /// <summary>
+    /// Called when RebornBuddy is shutting down or when the botbase is being unloaded.
+    /// </summary>
     void OnShutdown();
 
+    /// <summary>
+    /// Called on every RebornBuddy pulse (tick) while this botbase is active.
+    /// </summary>
     void Pulse();
 }

--- a/IDisposableCompiledBotbase.cs
+++ b/IDisposableCompiledBotbase.cs
@@ -1,14 +1,30 @@
-﻿using System;
+using System;
 
 namespace LlamaLibrary;
 
+/// <summary>
+/// Defines an extended contract for a synchronous botbase that is also <see cref="IDisposable"/>.
+/// Includes additional metadata and lifecycle methods for pulse and shutdown.
+/// </summary>
 public interface IDisposableCompiledBotbase : ICompiledBotbase, IDisposable
 {
+    /// <summary>
+    /// Gets the English display name of the botbase.
+    /// </summary>
     string EnglishName { get; }
 
+    /// <summary>
+    /// Gets the version of the botbase.
+    /// </summary>
     Version Version { get; }
 
+    /// <summary>
+    /// Called when RebornBuddy is shutting down or when the botbase is being unloaded.
+    /// </summary>
     void OnShutdown();
 
+    /// <summary>
+    /// Called on every RebornBuddy pulse (tick) while this botbase is active.
+    /// </summary>
     void Pulse();
 }


### PR DESCRIPTION
💡 **What:** Added XML documentation to several core interfaces including `ICompiledBotbase`, `ICompiledBotbaseFull`, `ICompiledAsyncBotbase`, `IExportedApi`, `ICompiledAPIBotbase`, `ICompiledPlugin`, `IDisposableCompiledBotbase`, and `IDisposableCompiledAsyncBotbase`.

🎯 **Why:** These interfaces define the primary contracts for botbases and plugins in LlamaLibrary but lacked detailed documentation on their lifecycle methods and properties, making them difficult for new developers to implement correctly.

🔬 **Examples:**
- `ICompiledBotbase.PulseFlags`: Added details about how it defines active RebornBuddy engine features.
- `ICompiledAsyncBotbase.AsyncRoot`: Described as the main asynchronous execution loop.
- `IExportedApi.Init`: Documented its role in component interaction.

---
*PR created automatically by Jules for task [10767872618277433720](https://jules.google.com/task/10767872618277433720) started by @nt153133*