### PR TITLE
📝 Scribe: Add XML documentation for LibraryClass and AssemblyProxy

### DIFF
--- a/AssemblyProxy.cs
+++ b/AssemblyProxy.cs
@@ -12,6 +12,11 @@ using Newtonsoft.Json.Serialization;
 
 namespace LlamaLibrary;
 
+/// <summary>
+/// Provides a proxy for resolving and loading assemblies within the RebornBuddy AppDomain.
+/// This ensures that dependencies like <c>Newtonsoft.Json</c> and <c>GreyMagic</c> are correctly resolved
+/// even when loaded from different contexts or versions.
+/// </summary>
 public static class AssemblyProxy
 {
     private static readonly ConcurrentDictionary<string, Assembly> Assemblies = new ConcurrentDictionary<string, Assembly>(StringComparer.Ordinal);
@@ -19,6 +24,10 @@ public static class AssemblyProxy
     private static bool _initialized;
     private static readonly object Lock = new object();
 
+    /// <summary>
+    /// Initializes the assembly proxy and registers core assemblies for resolution.
+    /// Also hooks into the <see cref="AppDomain.AssemblyResolve"/> event.
+    /// </summary>
     public static void Init()
     {
         lock (Lock)
@@ -56,6 +65,11 @@ public static class AssemblyProxy
         AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolve;
     }
 
+    /// <summary>
+    /// Registers an assembly with the proxy for later resolution.
+    /// </summary>
+    /// <param name="name">The short name of the assembly (e.g., "Newtonsoft").</param>
+    /// <param name="assembly">The <see cref="Assembly"/> instance to register.</param>
     public static void AddAssembly(string name, Assembly assembly)
     {
         if (string.IsNullOrEmpty(name))
@@ -81,6 +95,12 @@ public static class AssemblyProxy
         return null;
     }
 
+    /// <summary>
+    /// A manual assembly resolution handler that redirects core library requests to the correct instances.
+    /// </summary>
+    /// <param name="sender">The source of the event.</param>
+    /// <param name="args">The event data containing the name of the assembly to resolve.</param>
+    /// <returns>The resolved <see cref="Assembly"/>, or <see langword="null"/> if resolution fails.</returns>
     public static Assembly OnCurrentDomainOnAssemblyResolve(object sender, ResolveEventArgs args)
     {
         var assemblyName = new AssemblyName(args.Name);

--- a/LibraryClass.cs
+++ b/LibraryClass.cs
@@ -15,6 +15,10 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary;
 
+/// <summary>
+/// The main entry point for LlamaLibrary, implementing the RebornBuddy <see cref="ILibrary"/> interface.
+/// Handles early initialization, memory offset resolution, and safe mode detection.
+/// </summary>
 public class LibraryClass : ILibrary
 {
     private const string SafeModeArgument = "-safemode";
@@ -25,8 +29,17 @@ public class LibraryClass : ILibrary
     [DllImport("USER32.dll")]
     static extern short GetKeyState(VirtualKeyStates nVirtKey);
 
+    /// <summary>
+    /// Gets a value indicating whether the library is running in safe mode.
+    /// Safe mode disables or restricts certain features to prevent issues during startup or debugging.
+    /// </summary>
     public static bool SafeMode { get; private set; }
 
+    /// <summary>
+    /// Performs early initialization before memory offsets are resolved.
+    /// Checks for the "-safemode" command-line argument or Shift+Ctrl key combination to enable safe mode.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation, returning <see langword="true"/> if successful.</returns>
     public async Task<bool> PreOffsetWarmup()
     {
         foreach (var argument in Environment.GetCommandLineArgs())
@@ -58,6 +71,11 @@ public class LibraryClass : ILibrary
         return await OffsetManager.InitLib().ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Performs initialization after memory offsets have been resolved.
+    /// Sets up post-offset dependencies, login events, and hooks into the bot start cycle.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation, returning <see langword="true"/> if successful.</returns>
     public Task<bool> PostOffsetWarmup()
     {
         OffsetManager.SetPostOffsets();
@@ -127,6 +145,9 @@ public class LibraryClass : ILibrary
     }
 }
 
+/// <summary>
+/// Defines virtual key codes used for checking keyboard state via Win32 API.
+/// </summary>
 public enum VirtualKeyStates
 {
     VK_LBUTTON = 0x01,


### PR DESCRIPTION
Added XML documentation to `LibraryClass` and `AssemblyProxy` to improve codebase clarity and maintainability. These classes handle core initialization and assembly resolution for the library.

---
*PR created automatically by Jules for task [9825752599862633140](https://jules.google.com/task/9825752599862633140) started by @nt153133*