### PR TITLE
📝 Scribe: Add XML documentation for SnipeManager

### DIFF
--- a/LlamaManagers/SnipeManager.cs
+++ b/LlamaManagers/SnipeManager.cs
@@ -13,35 +13,60 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.LlamaManagers
 {
+    /// <summary>
+    /// Static manager for the FFXIV "Snipe" mini-game.
+    /// Handles reading mini-game state, identifying targetable objects, and executing shots via memory manipulation.
+    /// </summary>
     public class SnipeManager
     {
         private static LLogger Log = new LLogger("SnipeManager", Colors.Silver);
 
-        
-
+        /// <summary>
+        /// Gets the memory address of the SnipeManager instance in game memory.
+        /// </summary>
         public static IntPtr addr => Core.Memory.Read<IntPtr>(SnipeManagerOffsets.Instance);
+
+        /// <summary>
+        /// Gets the row ID of the current snipe instance from the Snipe sheet.
+        /// </summary>
         public static uint SnipeRowId => Core.Memory.Read<uint>(addr + SnipeManagerOffsets.Id);
 
+        /// <summary>
+        /// Gets or sets the current state of the snipe mini-game.
+        /// State 4 typically indicates the system is ready to fire.
+        /// </summary>
         public static byte State
         {
             get => Core.Memory.NoCacheRead<byte>(addr + SnipeManagerOffsets.State);
             set => Core.Memory.Write(addr + SnipeManagerOffsets.State, value);
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the snipe mini-game is currently active.
+        /// </summary>
         public static byte Active
         {
             get => Core.Memory.Read<byte>(addr + SnipeManagerOffsets.Active);
             set => Core.Memory.Write(addr + SnipeManagerOffsets.Active, value);
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether a shot is currently being processed.
+        /// </summary>
         private static bool Shoot
         {
             get => Core.Memory.Read<byte>(addr + SnipeManagerOffsets.Shoot) == 1;
             set => Core.Memory.Write(addr + SnipeManagerOffsets.Shoot, value ? 1 : 0);
         }
 
+        /// <summary>
+        /// Gets a pointer to the array of <see cref="SnipeObject"/>s currently present in the mini-game.
+        /// </summary>
         public static IntPtr SnipeObjectsPtr => Core.Memory.Read<IntPtr>(addr + SnipeManagerOffsets.SnipeObjects);
 
+        /// <summary>
+        /// Gets an array of <see cref="SnipeObject"/>s that can be targeted in the mini-game.
+        /// </summary>
         public static SnipeObject[] SnipeObjects
         {
             get
@@ -60,8 +85,17 @@ namespace LlamaLibrary.LlamaManagers
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the mini-game is in state 4, which is ready for user interaction/firing.
+        /// </summary>
         public static bool Ready => State == 4;
 
+        /// <summary>
+        /// Executes a snipe shot at the target object specified by <paramref name="index"/>.
+        /// Writes the necessary shoot data to memory and advances the state to trigger the shot.
+        /// </summary>
+        /// <param name="index">The zero-based index of the target in the <see cref="SnipeObjects"/> array.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static async Task Snipe(byte index)
         {
             if (addr == IntPtr.Zero)
@@ -100,6 +134,10 @@ namespace LlamaLibrary.LlamaManagers
         }
     }
 
+    /// <summary>
+    /// Represents a targetable object within the FFXIV snipe mini-game.
+    /// Maps to a 0x48 byte structure in game memory.
+    /// </summary>
     [StructLayout(layoutKind: LayoutKind.Explicit, Size = 0x48)]
     public struct SnipeObject
     {
@@ -128,14 +166,25 @@ namespace LlamaLibrary.LlamaManagers
         [FieldOffset(0x3e)]
         internal byte x3e;
 
+        /// <summary>
+        /// Gets a value indicating whether this object has been hit.
+        /// </summary>
         [FieldOffset(0x44)]
         public byte Hit;
 
+        /// <summary>
+        /// Returns a string representation of the snipe object, including its name and hit status.
+        /// </summary>
+        /// <returns>A string describing the object.</returns>
         public override string ToString()
         {
             return $"{GameObject?.Name ?? "Null Object"} - Hit:{Hit:X} - {x8:X} - {x18:X}:{x22:X} or {x34:X}:{x3e:X}";
         }
 
+        /// <summary>
+        /// Gets the live <see cref="ff14bot.Objects.GameObject"/> associated with this snipe target.
+        /// </summary>
+        /// <value>The <see cref="GameObject"/> instance, or <see langword="null"/> if the pointer is invalid.</value>
         public GameObject? GameObject
         {
             get


### PR DESCRIPTION
💡 **What:** The `SnipeManager` class and `SnipeObject` struct in `LlamaLibrary.LlamaManagers` received comprehensive triple-slash XML documentation.

🎯 **Why:** This manager handles complex, memory-mapped state for the FFXIV "Snipe" mini-game. Adding documentation clarifies how the mini-game state is read and manipulated, which is crucial for maintainability.

🔬 **Examples:**

```csharp
/// <summary>
/// Executes a snipe shot at the target object specified by <paramref name="index"/>.
/// Writes the necessary shoot data to memory and advances the state to trigger the shot.
/// </summary>
/// <param name="index">The zero-based index of the target in the <see cref="SnipeObjects"/> array.</param>
/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
public static async Task Snipe(byte index)
```

---
*PR created automatically by Jules for task [14465881496987500036](https://jules.google.com/task/14465881496987500036) started by @nt153133*