### PR TITLE
📝 Scribe: Add XML documentation for CollectablesShop and Conversation

### DIFF
--- a/RemoteWindows/CollectablesShop.cs
+++ b/RemoteWindows/CollectablesShop.cs
@@ -3,30 +3,63 @@ using ff14bot.Managers;
 
 namespace LlamaLibrary.RemoteWindows
 {
+    /// <summary>
+    /// Interface for the FFXIV Collectables Shop window.
+    /// Handles job selection, item selection, and item turn-ins for scrips.
+    /// </summary>
     //TODO Move element numbers to dictionary
     public class CollectablesShop : RemoteWindow<CollectablesShop>
     {
+        /// <summary>
+        /// Gets the total number of items eligible for turn-in in the current list.
+        /// Resolved via element index 20.
+        /// </summary>
         public int RowCount => Elements[20].Int - 1;
+
+        /// <summary>
+        /// Gets the count of items currently selected or ready for trade.
+        /// Resolved via element index 4843.
+        /// </summary>
         public int TurninCount => Elements[4843].Int;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CollectablesShop"/> class.
+        /// </summary>
         public CollectablesShop() : base("CollectablesShop")
         {
         }
 
+        /// <summary>
+        /// Selects a job category in the shop window.
+        /// </summary>
+        /// <param name="job">The zero-based index of the job to select.</param>
         public void SelectJob(int job)
         {
             SendAction(2, 3, 0xE, 4, (ulong)job);
         }
 
+        /// <summary>
+        /// Selects a specific item from the list to be traded.
+        /// </summary>
+        /// <param name="line">The zero-based index of the item line in the current list.</param>
         public void SelectItem(int line)
         {
             SendAction(2, 3, 0xC, 4, (ulong)line);
         }
 
+        /// <summary>
+        /// Executes the trade action for the currently selected item(s).
+        /// </summary>
         public void Trade()
         {
             SendAction(2, 3, 0xf, 4, 0);
         }
 
+        /// <summary>
+        /// Lists all items currently visible in the shop window with their formatted display strings.
+        /// Skips items with invalid IDs or IDs outside the 500,000–1,500,000 range.
+        /// </summary>
+        /// <returns>A list of strings in the format "Index: ItemName RawID".</returns>
         public List<string> ListItems()
         {
             var count = Elements[20].Int - 1;
@@ -53,6 +86,11 @@ namespace LlamaLibrary.RemoteWindows
             return result;
         }
 
+        /// <summary>
+        /// Retrieves a list of eligible items from the shop window, mapping them to their trade line indices.
+        /// Subtracts 500,000 from the raw game ID to resolve the actual <see cref="ff14bot.Managers.Item"/> ID.
+        /// </summary>
+        /// <returns>A list of tuples containing the Item ID and its corresponding line index.</returns>
         public List<(uint ItemId, int Line)> GetItems()
         {
             var count = Elements[20].Int - 1;

--- a/RemoteWindows/Conversation.cs
+++ b/RemoteWindows/Conversation.cs
@@ -8,10 +8,26 @@ using ff14bot.RemoteWindows;
 
 namespace LlamaLibrary.RemoteWindows
 {
+    /// <summary>
+    /// Static helper for interacting with various NPC dialogue selection windows.
+    /// Unified interface for <see cref="SelectString"/>, <see cref="SelectIconString"/>, and <see cref="CutSceneSelectString"/>.
+    /// </summary>
     public static class Conversation
     {
+        /// <summary>
+        /// Gets a value indicating whether any of the supported dialogue selection windows are currently open.
+        /// </summary>
         public static bool IsOpen => SelectString.IsOpen || SelectIconString.IsOpen || CutSceneSelectString.IsOpen;
+
+        /// <summary>
+        /// List of control character bytes (0x01, 0x02, 0x03, 0x16) often found in game strings that should be stripped for clean display/matching.
+        /// </summary>
         private static readonly byte[] badbytes = { 02, 0x16, 01, 03 };
+
+        /// <summary>
+        /// Gets the list of dialogue options from the currently open selection window.
+        /// For German and French clients, automatically cleans the strings by removing control characters.
+        /// </summary>
         public static List<string> GetConversationList
         {
             get
@@ -36,12 +52,21 @@ namespace LlamaLibrary.RemoteWindows
             }
         }
 
+        /// <summary>
+        /// Extension method to remove non-printable control characters (e.g., 0x01, 0x02) from a string.
+        /// </summary>
+        /// <param name="line">The string to clean.</param>
+        /// <returns>The cleaned string with control characters removed.</returns>
         public static string StripHypen(this string line)
         {
             var bytes = Encoding.UTF8.GetBytes(line).Where(i=> !badbytes.Contains(i)).ToArray();
             return Encoding.UTF8.GetString(bytes);
         }
 
+        /// <summary>
+        /// Selects the dialogue option at the specified index in the currently open selection window.
+        /// </summary>
+        /// <param name="line">The zero-based index of the line to select.</param>
         public static void SelectLine(uint line)
         {
             if (SelectString.IsOpen)
@@ -58,6 +83,11 @@ namespace LlamaLibrary.RemoteWindows
             }
         }
 
+        /// <summary>
+        /// Searches the current dialogue options for a line containing the specified text and selects it if found.
+        /// </summary>
+        /// <param name="line">The text to search for.</param>
+        /// <returns><see langword="true"/> if a matching line was found and selected; otherwise <see langword="false"/>.</returns>
         public static bool SelectLineContains(string line)
         {
             var index = GetConversationList.FindIndex(x => x.Contains(line, StringComparison.InvariantCultureIgnoreCase));
@@ -70,6 +100,9 @@ namespace LlamaLibrary.RemoteWindows
             return true;
         }
 
+        /// <summary>
+        /// Attempts to select the 'Quit' or 'Exit' option, which is typically the last item in the list.
+        /// </summary>
         public static void SelectQuit()
         {
             uint line;


### PR DESCRIPTION
💡 **What:** 
Added precise XML documentation to two key UI interaction classes: `CollectablesShop` and `Conversation`.

🎯 **Why:** 
These classes use "magic" element indices and specific domain logic (like the 500,000 item ID offset) that were previously opaque. Adding documentation ensures future maintainers understand the *why* behind these memory and UI interactions.

🔬 **Examples:**
`CollectablesShop.RowCount`: "Gets the total number of items eligible for turn-in... Resolved via element index 20."
`Conversation.StripHypen`: "Extension method to remove non-printable control characters (e.g., 0x01, 0x02) from a string."

---
*PR created automatically by Jules for task [5887666722263677042](https://jules.google.com/task/5887666722263677042) started by @nt153133*