### PR TITLE
📝 Scribe: Add XML documentation for Retainer classes

### DIFF
--- a/Retainers/CompleteRetainer.cs
+++ b/Retainers/CompleteRetainer.cs
@@ -6,20 +6,64 @@ using LlamaLibrary.Structs;
 
 namespace LlamaLibrary.Retainers
 {
+    /// <summary>
+    /// Represents a comprehensive snapshot of a retainer's current state.
+    /// This includes raw metadata from game memory, organized inventory lists, and calculated availability.
+    /// </summary>
     public class CompleteRetainer
     {
+        /// <summary>
+        /// Gets the raw memory metadata for the retainer, including name, level, job, and gil.
+        /// </summary>
         public RetainerInfo Info;
 
+        /// <summary>
+        /// Gets the number of items this retainer currently has listed for sale on the market board.
+        /// </summary>
         public int MBCount => ItemsForSale.Count;
+
+        /// <summary>
+        /// Gets a list of items currently listed for sale by this retainer on the market board.
+        /// </summary>
         public List<RetainerInventoryItem> ItemsForSale;
+
+        /// <summary>
+        /// Gets a list of items currently held in the retainer's personal inventory bags.
+        /// </summary>
         public List<RetainerInventoryItem> Inventory;
+
+        /// <summary>
+        /// Gets the zero-based index of this retainer in the player's total list of retainers.
+        /// </summary>
         public int Index;
+
+        /// <summary>
+        /// Gets the number of empty slots remaining in the retainer's standard inventory (out of 175).
+        /// </summary>
         public int FreeSlots => 175 - Inventory.Count;
+
+        /// <summary>
+        /// Gets the number of empty market board listing slots remaining (out of 20).
+        /// </summary>
         public int FreeSlotsMB => 20 - ItemsForSale.Count;
 
+        /// <summary>
+        /// Gets the localized <see cref="DateTime"/> indicating when the retainer's market board listing will time out.
+        /// </summary>
         public DateTime MBUpdated => DateTimeOffset.FromUnixTimeSeconds(Info.MBTimeOutTimestamp).LocalDateTime;
+
+        /// <summary>
+        /// Gets the localized <see cref="DateTime"/> indicating when the retainer's current venture will be completed.
+        /// </summary>
         public DateTime VentureEnd => DateTimeOffset.FromUnixTimeSeconds(Info.VentureEndTimestamp).LocalDateTime;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CompleteRetainer"/> class by capturing the state from provided <see cref="BagSlot"/> lists.
+        /// </summary>
+        /// <param name="info">The raw retainer metadata.</param>
+        /// <param name="index">The retainer's index in the list.</param>
+        /// <param name="itemsForSale">The raw list of slots from the market board bag.</param>
+        /// <param name="inventory">The raw list of slots from the retainer's inventory bags.</param>
         public CompleteRetainer(RetainerInfo info, int index, List<BagSlot> itemsForSale, List<BagSlot> inventory)
         {
             Info = info;

--- a/Retainers/RetainerInventoryItem.cs
+++ b/Retainers/RetainerInventoryItem.cs
@@ -1,14 +1,44 @@
 ﻿namespace LlamaLibrary.Retainers
 {
-    //TODO I'm baffled on how this is actually used right now
+    /// <summary>
+    /// Represents a single item within a retainer's inventory or market board listing.
+    /// This is a simplified data container used for snapshots and state tracking.
+    /// </summary>
     public class RetainerInventoryItem
     {
+        /// <summary>
+        /// Gets the unique identifier for the item, which includes high-quality (HQ) and collectable offsets.
+        /// </summary>
         public uint TrueItemID;
+
+        /// <summary>
+        /// Gets the base item ID as defined in the game's data sheets, excluding HQ or collectable status.
+        /// </summary>
         public uint RawItemID;
+
+        /// <summary>
+        /// Gets the number of items in this stack.
+        /// </summary>
         public uint Count;
+
+        /// <summary>
+        /// Gets the zero-based index of the inventory slot occupied by this item.
+        /// </summary>
         public int Slot;
+
+        /// <summary>
+        /// Gets a value indicating whether the item is of High Quality (HQ).
+        /// Determined by comparing <see cref="TrueItemID"/> with <see cref="RawItemID"/>.
+        /// </summary>
         public bool HQ => TrueItemID != RawItemID;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RetainerInventoryItem"/> class.
+        /// </summary>
+        /// <param name="trueItemId">The true item ID (including HQ/collectable offsets).</param>
+        /// <param name="rawItemId">The base item ID.</param>
+        /// <param name="count">The stack size.</param>
+        /// <param name="slot">The inventory slot index.</param>
         public RetainerInventoryItem(uint trueItemId, uint rawItemId, uint count, int slot)
         {
             TrueItemID = trueItemId;
@@ -17,11 +47,18 @@
             Slot = slot;
         }
 
+        /// <summary>
+        /// Determines whether the specified <see cref="RetainerInventoryItem"/> is equal to the current instance.
+        /// Equality is based on item ID, quantity, and slot index.
+        /// </summary>
+        /// <param name="other">The other item to compare.</param>
+        /// <returns><see langword="true"/> if the items are considered equal; otherwise <see langword="false"/>.</returns>
         protected bool Equals(RetainerInventoryItem other)
         {
             return TrueItemID == other.TrueItemID && Count == other.Count && Slot == other.Slot;
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is null)
@@ -42,6 +79,7 @@
             return Equals((RetainerInventoryItem)obj);
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked

--- a/Retainers/RetainerTaskData.cs
+++ b/Retainers/RetainerTaskData.cs
@@ -3,21 +3,72 @@ using Newtonsoft.Json;
 
 namespace LlamaLibrary.Retainers
 {
+    /// <summary>
+    /// Represents static data for a retainer venture task, typically loaded from an external JSON source or game data.
+    /// Includes requirements for assignment and details about the expected reward.
+    /// </summary>
     //TODO This needs to be somewhere else, Maybe a DataClass folder/namespace
     public class RetainerTaskData
     {
+        /// <summary>
+        /// Gets or sets the unique identifier for the venture task.
+        /// </summary>
         public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the category of class or job allowed to perform this venture.
+        /// </summary>
         public byte ClassJobCategory { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the venture reward is random (e.g., Quick Exploration).
+        /// </summary>
         public bool IsRandom { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum level the retainer must be to perform this venture.
+        /// </summary>
         public int RetainerLevel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of Venture scripts required to assign this task.
+        /// </summary>
         public int VentureCost { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum time (in minutes) the venture takes to complete.
+        /// </summary>
         public int MaxTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the amount of experience points the retainer earns upon completion.
+        /// </summary>
         public int Experience { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum item level required for the retainer to perform this venture.
+        /// </summary>
         public int RequiredItemLevel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum gathering stat required for the retainer to perform this venture (for gathering jobs).
+        /// </summary>
         public int RequiredGathering { get; set; }
+
+        /// <summary>
+        /// Gets or sets the raw name of the venture task as defined in the source data.
+        /// </summary>
         public string NameRaw { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID of the item rewarded by this venture (for non-random ventures).
+        /// </summary>
         public int ItemId { get; set; }
 
+        /// <summary>
+        /// Gets the display name of the venture.
+        /// For random ventures, returns <see cref="NameRaw"/>; for fixed ventures, resolves the localized name of the reward item.
+        /// </summary>
         [JsonIgnore]
         public string Name
         {
@@ -32,6 +83,20 @@ namespace LlamaLibrary.Retainers
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RetainerTaskData"/> class.
+        /// </summary>
+        /// <param name="id">The venture task ID.</param>
+        /// <param name="classJobCategory">The allowed class/job category.</param>
+        /// <param name="isRandom">Whether the reward is random.</param>
+        /// <param name="retainerLevel">Minimum retainer level.</param>
+        /// <param name="ventureCost">Cost in Venture currency.</param>
+        /// <param name="maxTime">Completion time in minutes.</param>
+        /// <param name="experience">XP reward.</param>
+        /// <param name="requiredItemLevel">Minimum iLvl requirement.</param>
+        /// <param name="requiredGathering">Minimum gathering requirement.</param>
+        /// <param name="nameRaw">Raw name string.</param>
+        /// <param name="itemId">Reward item ID.</param>
         [JsonConstructor]
         public RetainerTaskData(int id, byte classJobCategory, bool isRandom, int retainerLevel, int ventureCost, int maxTime, int experience, int requiredItemLevel, int requiredGathering, string nameRaw, int itemId)
         {
@@ -48,6 +113,7 @@ namespace LlamaLibrary.Retainers
             ItemId = itemId;
         }
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return $"{Id} - {IsRandom} {NameRaw}";


### PR DESCRIPTION
💡 **What:** Added XML documentation to `RetainerInventoryItem.cs`, `CompleteRetainer.cs`, and `RetainerTaskData.cs`.
🎯 **Why:** These classes are central to retainer state management but lacked clear documentation for their properties and calculated values.
🔬 **Examples:**
`public bool HQ => TrueItemID != RawItemID;` now has a summary explaining it's determined by comparing the two IDs.
`RetainerTaskData.Name` is documented to explain its conditional resolution between raw names and item names.

---
*PR created automatically by Jules for task [3845996583079544538](https://jules.google.com/task/3845996583079544538) started by @nt153133*