### PR TITLE
📝 Scribe: Add XML documentation for AgentGrandCompanySupply

### DIFF
--- a/RemoteAgents/AgentGrandCompanySupply.cs
+++ b/RemoteAgents/AgentGrandCompanySupply.cs
@@ -47,8 +47,9 @@ namespace LlamaLibrary.RemoteAgents
         /// Gets the list of items filtered and sorted for the Expert Delivery interface.
         /// </summary>
         /// <remarks>
-        /// This property skips the first 11 entries in the <see cref="SortArray"/> (which typically contain metadata)
-        /// and applies the current <see cref="ExpertFilter"/> and <see cref="HandinType"/> to the items.
+        /// This property skips the first 11 entries in the <see cref="SortArray"/>, which correspond to the 8 crafting (DOH)
+        /// and 3 gathering (DOL) daily turn-ins, and applies the current <see cref="ExpertFilter"/> and <see cref="HandinType"/>
+        /// to the remaining items.
         /// </remarks>
         public GCSupplyItem[] ExpertSupplyItems
         {

--- a/RemoteAgents/AgentGrandCompanySupply.cs
+++ b/RemoteAgents/AgentGrandCompanySupply.cs
@@ -9,20 +9,47 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Grand Company Supply and Expert Delivery interface.
+    /// Manages the list of items available for turn-in and handles filtering and sorting.
+    /// </summary>
     public class AgentGrandCompanySupply : AgentInterface<AgentGrandCompanySupply>, IAgent
     {
-        
-
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentGrandCompanySupplyOffsets.Vtable;
+
+        /// <summary>
+        /// Gets the memory pointer to the beginning of the supply item array.
+        /// </summary>
         public IntPtr SupplyItemPtr => Core.Memory.Read<IntPtr>(Pointer + AgentGrandCompanySupplyOffsets.ItemArrayStart);
+
+        /// <summary>
+        /// Gets the total number of items in the supply list.
+        /// </summary>
         public int SupplyItemCount => Core.Memory.Read<int>(Pointer + AgentGrandCompanySupplyOffsets.ArrayCount);
 
+        /// <summary>
+        /// Gets the memory pointer to the sorting array, which contains indices into the supply item array.
+        /// </summary>
         public IntPtr SortArrayPtr => Core.Memory.Read<IntPtr>(Pointer + AgentGrandCompanySupplyOffsets.SortArray);
 
+        /// <summary>
+        /// Gets the array of indices used to sort and display supply items.
+        /// </summary>
         public int[] SortArray => Core.Memory.ReadArray<int>(SortArrayPtr, SupplyItemCount);
 
+        /// <summary>
+        /// Gets the full array of <see cref="GCSupplyItem"/> entries from game memory.
+        /// </summary>
         public GCSupplyItem[] SupplyItems => Core.Memory.ReadArray<GCSupplyItem>(SupplyItemPtr, SupplyItemCount);
 
+        /// <summary>
+        /// Gets the list of items filtered and sorted for the Expert Delivery interface.
+        /// </summary>
+        /// <remarks>
+        /// This property skips the first 11 entries in the <see cref="SortArray"/> (which typically contain metadata)
+        /// and applies the current <see cref="ExpertFilter"/> and <see cref="HandinType"/> to the items.
+        /// </remarks>
         public GCSupplyItem[] ExpertSupplyItems
         {
             get
@@ -67,34 +94,56 @@ namespace LlamaLibrary.RemoteAgents
             }
         }
 
+        /// <summary>
+        /// Gets or sets the current hand-in category (Supply, Provisioning, or Expert).
+        /// </summary>
         public GCSupplyType HandinType
         {
             get => (GCSupplyType)Core.Memory.Read<byte>(Pointer + AgentGrandCompanySupplyOffsets.HandinType);
             set => Core.Memory.Write(Pointer + AgentGrandCompanySupplyOffsets.HandinType, (byte)value);
         }
 
+        /// <summary>
+        /// Gets or sets the active filter for Expert Delivery items.
+        /// </summary>
         public GCFilter ExpertFilter
         {
             get => (GCFilter)Core.Memory.Read<byte>(Pointer + AgentGrandCompanySupplyOffsets.ExpertFilter);
             set => Core.Memory.Write(Pointer + AgentGrandCompanySupplyOffsets.ExpertFilter, (byte)value);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentGrandCompanySupply"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentGrandCompanySupply(IntPtr pointer) : base(pointer)
         {
         }
     }
 
+    /// <summary>
+    /// Defines the categories of Grand Company turn-ins.
+    /// </summary>
     public enum GCSupplyType : byte
     {
+        /// <summary>Hand in crafted items for Disciple of the Hand jobs (Supply Missions).</summary>
         Supply = 0,
+        /// <summary>Hand in gathered items for Disciple of the Land jobs (Provisioning Missions).</summary>
         Provisioning = 1,
+        /// <summary>Hand in dungeon drops and gear for seals (Expert Delivery).</summary>
         Expert = 2,
     }
 
+    /// <summary>
+    /// Defines filtering options for the Grand Company Expert Delivery list.
+    /// </summary>
     public enum GCFilter : byte
     {
+        /// <summary>Show all eligible items.</summary>
         All = 0,
+        /// <summary>Hide items that are part of a registered gearset.</summary>
         HideGearSet = 1,
+        /// <summary>Hide items that are in the Armoury Chest.</summary>
         HideArmory = 2,
     }
 }

--- a/Structs/GCSupplyItem.cs
+++ b/Structs/GCSupplyItem.cs
@@ -5,39 +5,82 @@ using ff14bot.Managers;
 
 namespace LlamaLibrary.Structs
 {
+    /// <summary>
+    /// Represents an item entry in the Grand Company Supply or Expert Delivery list.
+    /// Maps to a 0xA0 byte structure in game memory used by the Grand Company Supply agent.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 0xA0)]
     public struct GCSupplyItem
     {
+        /// <summary>
+        /// Gets the memory pointer to the underlying game item object.
+        /// </summary>
         [FieldOffset(0)]
         public IntPtr ItemPtr;
 
+        /// <summary>
+        /// Gets the identifier of the inventory bag containing the item.
+        /// </summary>
         [FieldOffset(0x68)]
         public uint BagId;
 
+        /// <summary>
+        /// Gets the number of Grand Company seals awarded for handing in this item.
+        /// </summary>
         [FieldOffset(0x78)]
         public uint Seals;
 
+        /// <summary>
+        /// Gets the raw numeric identifier of the item.
+        /// </summary>
         [FieldOffset(0x84)]
         public uint ItemId;
 
+        /// <summary>
+        /// Gets the item level (iLevel) of the item.
+        /// </summary>
         [FieldOffset(0x94)]
         public short ItemLevel;
 
+        /// <summary>
+        /// Gets the index of the slot within the inventory bag.
+        /// </summary>
         [FieldOffset(0x97)]
         public ushort BagSlotId;
 
+        /// <summary>
+        /// Gets the type of hand-in category this item belongs to.
+        /// See <see cref="LlamaLibrary.RemoteAgents.GCSupplyType"/>.
+        /// </summary>
         [FieldOffset(0x99)]
         public byte HandInType;
 
+        /// <summary>
+        /// Gets a value indicating whether the item is currently part of any player gearset.
+        /// </summary>
         [FieldOffset(0x9C)]
         public bool InGearSet;
 
+        /// <summary>
+        /// Gets a value indicating whether the item is located in the player's Armoury Chest.
+        /// Derived from <see cref="BagId"/>.
+        /// </summary>
         public bool InArmory => BagId == 3500 || (BagId - 3200) <= 9 || BagId == 3300 || BagId == 3400;
 
+        /// <summary>
+        /// Gets the <see cref="ff14bot.Managers.BagSlot"/> instance corresponding to this item.
+        /// </summary>
         public BagSlot BagSlot => InventoryManager.GetBagByInventoryBagId((InventoryBagId)BagId)[BagSlotId];
 
+        /// <summary>
+        /// Gets a value indicating whether the item is High Quality (HQ).
+        /// </summary>
         public bool IsHQ => BagSlot.IsHighQuality;
 
+        /// <summary>
+        /// Returns a string representation of the supply item, including name, gearset status, and quality.
+        /// </summary>
+        /// <returns>A formatted string describing the item.</returns>
         public override string ToString()
         {
             return $"Item: {DataManager.GetItem(ItemId).CurrentLocaleName}, {nameof(InGearSet)}: {InGearSet}, {nameof(InArmory)}: {InArmory} HQ: {IsHQ}";


### PR DESCRIPTION
💡 **What:** Added comprehensive XML documentation for the `AgentGrandCompanySupply` class, its associated `GCSupplyType` and `GCFilter` enums, and the `GCSupplyItem` memory structure.
 
🎯 **Why:** These classes manage critical Grand Company turn-in logic and memory-mapped item data, which was previously undocumented and relied on non-obvious internal logic (such as the property that skips the first 11 metadata entries in the sorting array).
 
🔬 **Examples:**
```csharp
/// <summary>
/// Gets the list of items filtered and sorted for the Expert Delivery interface.
/// </summary>
/// <remarks>
/// This property skips the first 11 entries in the <see cref="SortArray"/> (which typically contain metadata)
/// and applies the current <see cref="ExpertFilter"/> and <see cref="HandinType"/> to the items.
/// </remarks>
public GCSupplyItem[] ExpertSupplyItems { get; }
```

---
*PR created automatically by Jules for task [12076681822909476511](https://jules.google.com/task/12076681822909476511) started by @nt153133*