### PR TITLE
📝 Scribe: Add XML documentation for OtherExtensions

### DIFF
--- a/Extensions/OtherExtensions.cs
+++ b/Extensions/OtherExtensions.cs
@@ -10,10 +10,19 @@ using Newtonsoft.Json.Converters;
 
 namespace LlamaLibrary.Extensions
 {
+    /// <summary>
+    /// Provides miscellaneous extension methods for common types like <see cref="Enum"/>, <see cref="IEnumerable{T}"/>, and <see cref="BoundingCircle"/>.
+    /// </summary>
     public static class OtherExtensions
     {
         private static readonly Random Rng = new();
 
+        /// <summary>
+        /// Converts an enum value to a string and adds spaces before each uppercase letter (except the first).
+        /// Useful for display purposes in a UI.
+        /// </summary>
+        /// <param name="toText">The enum value to format.</param>
+        /// <returns>A string representation of the enum with spaces added.</returns>
         public static string AddSpacesToEnum(this Enum toText)
         {
             var text = toText.ToString();
@@ -37,11 +46,26 @@ namespace LlamaLibrary.Extensions
             return newText.ToString();
         }
 
+        /// <summary>
+        /// Randomly shuffles the elements of an <see cref="IEnumerable{T}"/> using the default random number generator.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the collection.</typeparam>
+        /// <param name="source">The collection to shuffle.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> with shuffled elements.</returns>
         public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source)
         {
             return source.Shuffle(Rng);
         }
 
+        /// <summary>
+        /// Randomly shuffles the elements of an <see cref="IEnumerable{T}"/> using a specified random number generator.
+        /// Uses the Fisher-Yates shuffle algorithm.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the collection.</typeparam>
+        /// <param name="source">The collection to shuffle.</param>
+        /// <param name="rng">The random number generator to use.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> with shuffled elements.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="source"/> or <paramref name="rng"/> is null.</exception>
         public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source, Random rng)
         {
             if (source == null)
@@ -70,6 +94,12 @@ namespace LlamaLibrary.Extensions
             }
         }
 
+        /// <summary>
+        /// Serializes a collection of Lisbeth <see cref="Order"/> objects into a JSON string.
+        /// Configured to ignore null and default values and use string representations for enums.
+        /// </summary>
+        /// <param name="orders">The collection of orders to serialize.</param>
+        /// <returns>A formatted JSON string representing the orders, sorted by their type.</returns>
         public static string GetOrderJson(this IEnumerable<Order> orders)
         {
             var settings = new JsonSerializerSettings
@@ -81,16 +111,35 @@ namespace LlamaLibrary.Extensions
             return JsonConvert.SerializeObject(orders.OrderBy(i => i.Type), Formatting.Indented, settings);
         }
 
+        /// <summary>
+        /// Determines whether a string contains a specified substring using the specified comparison rules.
+        /// </summary>
+        /// <param name="source">The source string to search.</param>
+        /// <param name="toCheck">The substring to look for.</param>
+        /// <param name="comp">One of the enumeration values that specifies the rules for the search.</param>
+        /// <returns><see langword="true"/> if the substring is found; otherwise <see langword="false"/>.</returns>
         public static bool Contains(this string? source, string toCheck, StringComparison comp)
         {
             return source?.IndexOf(toCheck, comp) >= 0;
         }
 
+        /// <summary>
+        /// Determines whether a 2D point is within the bounds of a <see cref="BoundingCircle"/>.
+        /// </summary>
+        /// <param name="source">The bounding circle.</param>
+        /// <param name="toCheck">The 2D coordinates to check.</param>
+        /// <returns><see langword="true"/> if the point is inside or on the boundary of the circle; otherwise <see langword="false"/>.</returns>
         public static bool Contains(this BoundingCircle source, Vector2 toCheck)
         {
             return source.Center.ToVector2().Distance(toCheck) <= source.Radius;
         }
 
+        /// <summary>
+        /// Determines whether a 3D point is within the 2D bounds of a <see cref="BoundingCircle"/>, ignoring the Z-axis.
+        /// </summary>
+        /// <param name="source">The bounding circle.</param>
+        /// <param name="toCheck">The 3D coordinates to check.</param>
+        /// <returns><see langword="true"/> if the projected 2D point is inside or on the boundary of the circle; otherwise <see langword="false"/>.</returns>
         public static bool ContainsIgnoreZ(this BoundingCircle source, Vector3 toCheck)
         {
             return source.Center.ToVector2().Distance(toCheck.ToVector2()) <= source.Radius;


### PR DESCRIPTION
💡 **What:** XML documentation for the `OtherExtensions` class and its methods in `Extensions/OtherExtensions.cs`.
 
🎯 **Why:** This utility class provides various helper methods used throughout the library but lacked documentation explaining their intent and spatial logic (especially for `BoundingCircle` containment).
 
🔬 **Examples:**
```csharp
        /// <summary>
        /// Randomly shuffles the elements of an <see cref="IEnumerable{T}"/> using a specified random number generator.
        /// Uses the Fisher-Yates shuffle algorithm.
        /// </summary>
        /// <typeparam name="T">The type of elements in the collection.</typeparam>
        /// <param name="source">The collection to shuffle.</param>
        /// <param name="rng">The random number generator to use.</param>
        /// <returns>An <see cref="IEnumerable{T}"/> with shuffled elements.</returns>
        /// <exception cref="ArgumentNullException">Thrown if <paramref name="source"/> or <paramref name="rng"/> is null.</exception>
```

---
*PR created automatically by Jules for task [13874979032433615404](https://jules.google.com/task/13874979032433615404) started by @nt153133*