### PR TITLE
📝 Scribe: Add XML documentation for Extension Classes

### DIFF
--- a/Extensions/BagExtensions.cs
+++ b/Extensions/BagExtensions.cs
@@ -5,18 +5,36 @@ using ff14bot.Managers;
 
 namespace LlamaLibrary.Extensions
 {
+    /// <summary>
+    /// Provides extension methods for the <see cref="Bag"/> and collections of bag identifiers.
+    /// </summary>
     public static class BagExtensions
     {
+        /// <summary>
+        /// Retrieves the first available empty slot within the specified bag.
+        /// </summary>
+        /// <param name="bag">The bag to search.</param>
+        /// <returns>The first empty <see cref="BagSlot"/>, or <see langword="null"/> if the bag is full.</returns>
         public static BagSlot? GetFirstFreeSlot(this Bag bag)
         {
             return bag.FreeSlots > 0 ? bag.First(i => !i.IsFilled) : null;
         }
 
+        /// <summary>
+        /// Searches through a sequence of bag IDs and returns the first empty slot found.
+        /// </summary>
+        /// <param name="bagIds">The sequence of inventory bag identifiers to search.</param>
+        /// <returns>The first empty <see cref="BagSlot"/> found, or <see langword="null"/> if all bags are full.</returns>
         public static BagSlot? NextFreeBagSlot(this IEnumerable<InventoryBagId> bagIds)
         {
             return (from bagId in bagIds select InventoryManager.GetBagByInventoryBagId(bagId) into freeSlots where freeSlots.FreeSlots > 0 select freeSlots.First(i => !i.IsFilled)).FirstOrDefault();
         }
 
+        /// <summary>
+        /// Searches through a collection of bags and returns the first empty slot found.
+        /// </summary>
+        /// <param name="bags">The collection of bags to search.</param>
+        /// <returns>The first empty <see cref="BagSlot"/> found, or <see langword="null"/> if all bags are full.</returns>
         public static BagSlot? NextFreeBagSlot(this IEnumerable<Bag> bags)
         {
             return (from bag in bags where bag.FreeSlots > 0 select bag.First(i => !i.IsFilled)).FirstOrDefault();

--- a/Extensions/EventNpcExtensions.cs
+++ b/Extensions/EventNpcExtensions.cs
@@ -7,15 +7,27 @@ using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.Extensions
 {
+    /// <summary>
+    /// Provides extension methods for the <see cref="GameObject"/> and <see cref="BattleCharacter"/> classes,
+    /// specifically for event NPC and player interactions.
+    /// </summary>
     public static class EventNpcExtensions
     {
-
-
+        /// <summary>
+        /// Retrieves the icon identifier for an event NPC.
+        /// </summary>
+        /// <param name="eventNpc">The game object instance (must be an <see cref="GameObjectType.EventNpc"/>).</param>
+        /// <returns>The numeric icon ID, or 0 if the object is not an event NPC.</returns>
         public static uint IconId(this GameObject eventNpc)
         {
             return eventNpc.Type == GameObjectType.EventNpc ? Core.Memory.Read<uint>(eventNpc.Pointer + EventNpcExtensionsOffsets.IconID) : 0U;
         }
 
+        /// <summary>
+        /// Attempts to open the trade window with another player character.
+        /// </summary>
+        /// <param name="otherPlayer">The player character to trade with.</param>
+        /// <returns>A status code from the game's internal trade window function, or -1 if the target is not a player.</returns>
         public static int OpenTradeWindow(this BattleCharacter otherPlayer)
         {
             return otherPlayer.Type == GameObjectType.Pc ? Core.Memory.CallInjectedWraper<IntPtr>(Offsets.OpenTradeWindow, Offsets.g_InventoryManager, otherPlayer.ObjectId).ToInt32() : -1;

--- a/Extensions/GatheringPointObjectExtensions.cs
+++ b/Extensions/GatheringPointObjectExtensions.cs
@@ -3,8 +3,16 @@ using ff14bot.Objects;
 
 namespace LlamaLibrary.Extensions
 {
+    /// <summary>
+    /// Provides extension methods for the <see cref="GatheringPointObject"/> class.
+    /// </summary>
     public static class GatheringPointObjectExtensions
     {
+        /// <summary>
+        /// Retrieves the internal base identifier for the specified gathering node by reading from memory.
+        /// </summary>
+        /// <param name="node">The gathering point object instance.</param>
+        /// <returns>The numeric base ID of the node.</returns>
         public static int Base(this GatheringPointObject node)
         {
             return (int)Core.Memory.Read<uint>(node.Pointer + 0x80);

--- a/Extensions/ItemExtensions.cs
+++ b/Extensions/ItemExtensions.cs
@@ -3,13 +3,26 @@ using LlamaLibrary.Enums;
 
 namespace LlamaLibrary.Extensions
 {
+    /// <summary>
+    /// Provides extension methods for the <see cref="Item"/> class.
+    /// </summary>
     public static class ItemExtensions
     {
+        /// <summary>
+        /// Gets the internal item role for this item, cast to the <see cref="MyItemRole"/> enum.
+        /// </summary>
+        /// <param name="item">The item instance.</param>
+        /// <returns>The <see cref="MyItemRole"/> value for the item.</returns>
         public static MyItemRole MyItemRole(this Item item)
         {
             return (MyItemRole)(byte)item.ItemRole;
         }
 
+        /// <summary>
+        /// Gets the localized name of the item, appending "(HQ)" if the item is High Quality.
+        /// </summary>
+        /// <param name="item">The item instance.</param>
+        /// <returns>The localized name string.</returns>
         public static string LocaleName(this Item item)
         {
             return item.IsHighQuality ? $"{item.CurrentLocaleName} (HQ)" : item.CurrentLocaleName;


### PR DESCRIPTION
💡 **What:** Added triple-slash XML documentation for extension methods in `BagExtensions`, `EventNpcExtensions`, `GatheringPointObjectExtensions`, and `ItemExtensions`.
 
🎯 **Why:** These utility classes provide core functionality for inventory management, NPC interaction, and data retrieval but lacked public-facing documentation. This update improves IDE intellisense and codebase maintainability.
 
🔬 **Examples:**
```csharp
/// <summary>
/// Retrieves the internal base identifier for the specified gathering node by reading from memory.
/// </summary>
/// <param name="node">The gathering point object instance.</param>
/// <returns>The numeric base ID of the node.</returns>
public static int Base(this GatheringPointObject node)
{
    return (int)Core.Memory.Read<uint>(node.Pointer + 0x80);
}
```

---
*PR created automatically by Jules for task [3785657326935542373](https://jules.google.com/task/3785657326935542373) started by @nt153133*