### PR TITLE
📝 Scribe: Add XML documentation for RemoteAgents and PointMenuManager

### DIFF
--- a/LlamaManagers/PointMenuManager.cs
+++ b/LlamaManagers/PointMenuManager.cs
@@ -1,4 +1,4 @@
-﻿#if RB_DT
+#if RB_DT
 using System;
 using System.Windows.Media;
 using ff14bot;
@@ -8,15 +8,28 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.LlamaManagers
 {
+    /// <summary>
+    /// Static manager for the "PointMenu" UI window, introduced in the Dawntrail expansion.
+    /// Handles interaction with point-and-click investigation elements in the game world.
+    /// </summary>
     public class PointMenuManager
     {
         private static LLogger Log = new LLogger("PointMenu", Colors.Silver);
-        
 
+        /// <summary>
+        /// Gets the <see cref="AtkAddonControl"/> for the "PointMenu" window if it is open.
+        /// </summary>
         public static AtkAddonControl Window => RaptureAtkUnitManager.GetWindowByName("PointMenu");
 
+        /// <summary>
+        /// Gets a vector of pointers to the interactive objects currently managed by the PointMenu window.
+        /// </summary>
         public static NativeVectorV2<IntPtr> Objects => Core.Memory.Read<NativeVectorV2<IntPtr>>(Window.Pointer + PointMenuManagerOffsets.ObjectCount);
 
+        /// <summary>
+        /// Interacts with an object in the PointMenu at the specified index/position.
+        /// </summary>
+        /// <param name="position">The zero-based index of the object to interact with.</param>
         public static void Interact(ulong position)
         {
             Log.Information($"Clicking on {position}");

--- a/RemoteAgents/AgentBagSlot.cs
+++ b/RemoteAgents/AgentBagSlot.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using ff14bot;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
@@ -6,15 +6,26 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for interacting with individual bag slots and their associated context menus/actions.
+    /// Used for specialized item actions like aetherial reduction.
+    /// </summary>
     public class AgentBagSlot : AgentInterface<AgentBagSlot>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentBagSlotOffsets.VTable;
-        
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentBagSlot"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentBagSlot(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Gets the memory pointer used for triggering aetherial reduction on the current slot.
+        /// </summary>
         public IntPtr PointerForAether => Core.Memory.Read<IntPtr>(Core.Memory.Read<IntPtr>(Pointer + AgentBagSlotOffsets.Offset) + (0x20 * 7) + AgentBagSlotOffsets.FuncOffset);
     }
 }

--- a/RemoteAgents/AgentCharacter.cs
+++ b/RemoteAgents/AgentCharacter.cs
@@ -1,18 +1,25 @@
-﻿using System;
+using System;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the "Character" window.
+    /// Provides access to character attributes, equipment, and profile data.
+    /// </summary>
     public class AgentCharacter : AgentInterface<AgentCharacter>, IAgent
     {
-        
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentCharacter"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentCharacter(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentCharacterOffsets.Vtable;
     }
 }

--- a/RemoteAgents/AgentInventoryBuddy.cs
+++ b/RemoteAgents/AgentInventoryBuddy.cs
@@ -1,16 +1,23 @@
-﻿using System;
+using System;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the "InventoryBuddy" window (Chocobo Saddlebag).
+    /// Handles the data and logic for managing items stored in the player's chocobo saddlebags.
+    /// </summary>
     public class AgentInventoryBuddy : AgentInterface<AgentInventoryBuddy>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentInventoryBuddyOffsets.VTable;
 
-        
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentInventoryBuddy"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentInventoryBuddy(IntPtr pointer) : base(pointer)
         {
         }

--- a/RemoteAgents/AgentItemDetail.cs
+++ b/RemoteAgents/AgentItemDetail.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using ff14bot;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
@@ -6,16 +6,26 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the item detail tooltip.
+    /// Manages information about the item currently being hovered over in the UI.
+    /// </summary>
     public class AgentItemDetail : AgentInterface<AgentItemDetail>, IAgent
     {
-        
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentItemDetail"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentItemDetail(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentItemDetailOffsets.Vtable;
 
+        /// <summary>
+        /// Gets the ID of the item currently being hovered over in the game UI.
+        /// </summary>
         public uint HoverOverItemID => Core.Memory.Read<uint>(Pointer + AgentItemDetailOffsets.ItemID);
     }
 }

--- a/RemoteAgents/AgentRetainerInventory.cs
+++ b/RemoteAgents/AgentRetainerInventory.cs
@@ -1,20 +1,31 @@
-﻿using ff14bot;
+using ff14bot;
 using ff14bot.Managers;
 using LlamaLibrary.Memory;
 using System;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the retainer inventory interface.
+    /// Manages the data and logic for viewing and interacting with a retainer's current inventory.
+    /// </summary>
     public class AgentRetainerInventory : AgentInterface<AgentRetainerInventory>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentRetainerInventoryOffsets.VTable;
         // ReSharper disable once PartialTypeWithSinglePart
 
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentRetainerInventory"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentRetainerInventory(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Gets the memory pointer to the retainer's shop interface data.
+        /// </summary>
         public IntPtr RetainerShopPointer => Core.Memory.Read<IntPtr>(Pointer + AgentRetainerInventoryOffsets.ShopOffset);
     }
 }


### PR DESCRIPTION
💡 **What:** Added XML documentation to several `RemoteAgents` (`AgentInventoryBuddy`, `AgentCharacter`, `AgentBagSlot`, `AgentItemDetail`, `AgentRetainerInventory`) and the `PointMenuManager`.
🎯 **Why:** These components lacked documentation for their roles and specific memory-mapped properties, which are critical for understanding how the library interacts with game UI and items.
🔬 **Examples:**
- `AgentBagSlot.PointerForAether`: "Gets the memory pointer used for triggering aetherial reduction on the current slot."
- `PointMenuManager`: "Static manager for the 'PointMenu' UI window, introduced in the Dawntrail expansion."
- `AgentItemDetail.HoverOverItemID`: "Gets the ID of the item currently being hovered over in the game UI."

---
*PR created automatically by Jules for task [16969015393912997587](https://jules.google.com/task/16969015393912997587) started by @nt153133*