### PR TITLE
📝 Scribe: Add XML documentation for ResourceManager, ProductPatterns, and PointMenuManager

### DIFF
--- a/LlamaManagers/PointMenuManager.cs
+++ b/LlamaManagers/PointMenuManager.cs
@@ -8,15 +8,28 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.LlamaManagers
 {
+    /// <summary>
+    /// Manages interactions with the 'PointMenu' UI window, primarily used for investigation and point-and-click
+    /// mechanics introduced in the Dawntrail expansion.
+    /// </summary>
     public class PointMenuManager
     {
         private static LLogger Log = new LLogger("PointMenu", Colors.Silver);
-        
 
+        /// <summary>
+        /// Gets the <see cref="AtkAddonControl"/> for the 'PointMenu' window.
+        /// </summary>
         public static AtkAddonControl Window => RaptureAtkUnitManager.GetWindowByName("PointMenu");
 
+        /// <summary>
+        /// Gets a collection of memory pointers to the interactive objects currently managed by the PointMenu.
+        /// </summary>
         public static NativeVectorV2<IntPtr> Objects => Core.Memory.Read<NativeVectorV2<IntPtr>>(Window.Pointer + PointMenuManagerOffsets.ObjectCount);
 
+        /// <summary>
+        /// Simulates a user interaction (click) on a specific element within the PointMenu.
+        /// </summary>
+        /// <param name="position">The index or identifier of the object to interact with.</param>
         public static void Interact(ulong position)
         {
             Log.Information($"Clicking on {position}");

--- a/ProductPatterns.cs
+++ b/ProductPatterns.cs
@@ -2,18 +2,47 @@
 
 namespace LlamaLibrary;
 
+/// <summary>
+/// Represents a collection of memory search patterns and associated metadata for a specific game client product or region.
+/// </summary>
 public class ProductPatterns
 {
+    /// <summary>
+    /// Gets or sets the display name of the product or library (e.g., "LlamaLibrary").
+    /// </summary>
     public string ProductName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the geographic or version-specific region of the game client.
+    /// Defaults to <see cref="ClientRegion.NotSpecified"/>.
+    /// </summary>
     public ClientRegion ClientRegion { get; set; } = ClientRegion.NotSpecified;
-    public Dictionary<string,string> Patterns { get; set; }
+
+    /// <summary>
+    /// Gets or sets the dictionary of memory patterns, where the key is a unique identifier (e.g., "VTable")
+    /// and the value is the raw pattern string used for scanning.
+    /// </summary>
+    public Dictionary<string, string> Patterns { get; set; }
 }
 
+/// <summary>
+/// Specifies the geographic region or distribution of the Final Fantasy XIV game client.
+/// Used to differentiate between different binary structures and memory offsets.
+/// </summary>
 public enum ClientRegion
 {
+    /// <summary>The international version of the game client.</summary>
     Global,
+
+    /// <summary>The Chinese (Shengqu Games) version of the game client.</summary>
     China,
+
+    /// <summary>The Korean (Actoz Soft) version of the game client.</summary>
     Korea,
+
+    /// <summary>The Traditional Chinese version of the game client.</summary>
     TraditionalChinese,
+
+    /// <summary>Region not specified or unknown.</summary>
     NotSpecified
 }

--- a/ResourceManager.cs
+++ b/ResourceManager.cs
@@ -9,14 +9,45 @@ using Newtonsoft.Json;
 
 namespace LlamaLibrary
 {
+    /// <summary>
+    /// Provides thread-safe, deferred access to static game data resources stored as JSON.
+    /// Manages information for Materia, Hunts, Ventures, Custom Deliveries, Housing, and Grand Company shops.
+    /// </summary>
     public static class ResourceManager
     {
+        /// <summary>
+        /// Gets the collection of Materia items, indexed by their tier or type.
+        /// </summary>
         public static readonly Lazy<Dictionary<int, List<MateriaItem>>> MateriaList;
+
+        /// <summary>
+        /// Gets the collection of daily hunt locations, sorted by their identifier.
+        /// </summary>
         public static readonly Lazy<SortedDictionary<int, StoredHuntLocation>> DailyHunts;
+
+        /// <summary>
+        /// Gets the list of available retainer venture tasks and their associated requirements/rewards.
+        /// </summary>
         public static readonly Lazy<List<RetainerTaskData>> VentureData;
+
+        /// <summary>
+        /// Gets the list of NPCs that participate in the Custom Delivery system.
+        /// </summary>
         public static readonly Lazy<List<CustomDeliveryNpc>> CustomDeliveryNpcs;
+
+        /// <summary>
+        /// Gets a mapping of housing zones to their respective plot data, including location coordinates.
+        /// </summary>
         public static readonly Dictionary<HousingZone, Lazy<Dictionary<int, RecordedPlot>>> HousingPlots;
+
+        /// <summary>
+        /// Gets the collection of items available for purchase from Grand Company quartermasters, indexed by company.
+        /// </summary>
         public static readonly Dictionary<GrandCompany, List<GCShopItemStored>> GCShopItems;
+
+        /// <summary>
+        /// Gets the collection of crafting recipes associated with Anden's custom deliveries.
+        /// </summary>
         public static readonly Dictionary<uint, List<StoredRecipe>> Recipes_Anden;
 
         static ResourceManager()
@@ -39,6 +70,12 @@ namespace LlamaLibrary
             };
         }
 
+        /// <summary>
+        /// Deserializes a JSON resource string into the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to deserialize to.</typeparam>
+        /// <param name="text">The JSON string content to deserialize.</param>
+        /// <returns>The deserialized object of type <typeparamref name="T"/>.</returns>
         public static T LoadResource<T>(string text)
         {
             return JsonConvert.DeserializeObject<T>(text);


### PR DESCRIPTION
💡 **What:** Added XML documentation to `ResourceManager.cs`, `ProductPatterns.cs`, and `LlamaManagers/PointMenuManager.cs`.
🎯 **Why:** These are core utility and manager classes that lacked clear definitions of their purpose and members, especially regarding domain-specific data like Dawntrail investigation menus and multi-region client support.
🔬 **Examples:**
- `PointMenuManager`: "Manages interactions with the 'PointMenu' UI window, primarily used for investigation and point-and-click mechanics introduced in the Dawntrail expansion."
- `ClientRegion`: "Specifies the geographic region or distribution of the Final Fantasy XIV game client."
- `ResourceManager`: "Provides thread-safe, deferred access to static game data resources stored as JSON."

---
*PR created automatically by Jules for task [6254864593295228675](https://jules.google.com/task/6254864593295228675) started by @nt153133*