### PR TITLE
📝 Scribe: Add XML documentation for RemoteAgents

### DIFF
--- a/RemoteAgents/AgentAWGrowthFragTrade.cs
+++ b/RemoteAgents/AgentAWGrowthFragTrade.cs
@@ -15,29 +15,61 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Anima Weapon "Growth Fragment" (Crystal Sand) exchange interface.
+    /// Facilitates the conversion of various items and currencies into Crystal Sand.
+    /// </summary>
     public class AgentAWGrowthFragTrade : AgentInterface<AgentAWGrowthFragTrade>, IAgent
     {
+        /// <summary>
+        /// Logger for the growth fragment trade agent.
+        /// </summary>
         public static LLogger Log = new LLogger("AgentAWGrowthFragTrade", Colors.Lavender);
 
-        
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentAWGrowthFragTrade"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentAWGrowthFragTrade(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentAWGrowthFragTradeOffsets.Vtable;
 
+        /// <summary>
+        /// Gets the memory pointer to the start of the exchange items array.
+        /// </summary>
         public IntPtr ArrayPtr => Pointer + AgentAWGrowthFragTradeOffsets.ArrayBase;
 
+        /// <summary>
+        /// Gets the number of exchange options available in the interface.
+        /// </summary>
         public int ArrayCount => Core.Memory.Read<int>(Pointer + AgentAWGrowthFragTradeOffsets.ArrayCount);
 
+        /// <summary>
+        /// Gets an array of <see cref="AnimaExchangeItemInfo"/> representing the available trade-in options.
+        /// </summary>
         public AnimaExchangeItemInfo[] ExchangeItems => Core.Memory.ReadArray<AnimaExchangeItemInfo>(ArrayPtr, ArrayCount);
 
+        /// <summary>
+        /// Executes a purchase action for the specified exchange option.
+        /// </summary>
+        /// <param name="index">The zero-based index of the exchange item to buy.</param>
+        /// <param name="qty">The quantity to purchase.</param>
         public void Buy(int index, int qty)
         {
             Core.Memory.CallInjectedWraper<int>(AgentAWGrowthFragTradeOffsets.BuyFunction, Pointer, index, qty);
         }
 
+        /// <summary>
+        /// Orchestrates the purchase of Crystal Sand using a specified currency or item.
+        /// Handles opening/closing the UI, identifying the correct exchange category, and verifying the purchase outcome.
+        /// </summary>
+        /// <param name="itemToSpend">The item ID of the currency or item to be traded in.</param>
+        /// <param name="qty">The desired quantity of Crystal Sand to purchase.</param>
+        /// <param name="buyAnyAmount">If <see langword="true"/>, purchases as much as possible if the desired <paramref name="qty"/> cannot be met; otherwise, fails if the full amount is unavailable.</param>
+        /// <returns><see langword="true"/> if at least some Crystal Sand was successfully purchased; otherwise <see langword="false"/>.</returns>
         public static async Task<bool> BuyCrystalSand(uint itemToSpend, int qty, bool buyAnyAmount = false)
         {
             if (!await AWGrowthFragTrade.OpenExchangeWindow())

--- a/RemoteAgents/AgentAchievement.cs
+++ b/RemoteAgents/AgentAchievement.cs
@@ -6,14 +6,26 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Achievement interface.
+    /// Manages the display and state of the player's achievements.
+    /// </summary>
     public class AgentAchievement : AgentInterface<AgentAchievement>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentAchievementOffsets.VTable;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentAchievement"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentAchievement(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Gets the current status byte of the achievement agent.
+        /// </summary>
         public byte Status => Core.Memory.NoCacheRead<byte>(Pointer + AgentAchievementOffsets.Status);
 
         private static readonly Dictionary<string, int> VFunctionIds = new()
@@ -24,8 +36,14 @@ namespace LlamaLibrary.RemoteAgents
             { "GetAddonId", 9 },
         };
 
+        /// <summary>
+        /// Gets a value indicating whether the agent is currently active by calling its internal "IsAgentActive" virtual function.
+        /// </summary>
         private bool IsAgentActive => Core.Memory.CallInjected64<byte>(VFunctionAddress("IsAgentActive"), Pointer) == 1;
 
+        /// <summary>
+        /// Gets a value indicating whether the achievement window is currently open.
+        /// </summary>
         public bool IsOpen => IsAgentActive;
 
         private IntPtr VFunctionAddress(string function)

--- a/RemoteAgents/AgentContentsInfo.cs
+++ b/RemoteAgents/AgentContentsInfo.cs
@@ -5,11 +5,18 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the "Contents Info" (Duty Recorder / Duty List) interface.
+    /// </summary>
     public class AgentContentsInfo : AgentInterface<AgentContentsInfo>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentContentsInfoOffsets.VTable;
-        
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentContentsInfo"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentContentsInfo(IntPtr pointer) : base(pointer)
         {
         }

--- a/RemoteAgents/AgentFateProgress.cs
+++ b/RemoteAgents/AgentFateProgress.cs
@@ -6,17 +6,31 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the "Shared FATE" progress interface.
+    /// Manages information about rank and completion status for FATEs across different zones.
+    /// </summary>
     public class AgentFateProgress : AgentInterface<AgentFateProgress>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentFateProgressOffsets.VTable;
-        
 
+        /// <summary>
+        /// Gets the number of zones with loaded FATE progress data.
+        /// </summary>
         public int NumberOfLoadedZones => 0; //Core.Memory.NoCacheRead<byte>(Pointer + Offsets.LoadedZones);
 
+        /// <summary>
+        /// Gets an array of <see cref="SharedFateProgress"/> structures for the loaded zones.
+        /// </summary>
         public SharedFateProgress[] ProgressArray => new SharedFateProgress[0];
 
         //Core.Memory.ReadArray<SharedFateProgress>(Core.Memory.Read<IntPtr>(Pointer + Offsets.ZoneStructs), NumberOfLoadedZones);
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentFateProgress"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentFateProgress(IntPtr pointer) : base(pointer)
         {
         }

--- a/RemoteAgents/AgentItemAppraisal.cs
+++ b/RemoteAgents/AgentItemAppraisal.cs
@@ -5,12 +5,18 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the item appraisal interface (e.g., for Eureka/Bozja lockboxes or PotD/HoH sacks).
+    /// </summary>
     public class AgentItemAppraisal : AgentInterface<AgentItemAppraisal>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentItemAppraisalOffsets.VTable;
 
-        
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentItemAppraisal"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentItemAppraisal(IntPtr pointer) : base(pointer)
         {
         }

--- a/RemoteAgents/AgentJournalDetail.cs
+++ b/RemoteAgents/AgentJournalDetail.cs
@@ -5,12 +5,19 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Journal Detail window.
+    /// Manages the display of detailed information for selected quests or duties in the journal.
+    /// </summary>
     public class AgentJournalDetail : AgentInterface<AgentJournalDetail>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentJournalDetailOffsets.VTable;
 
-        
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentJournalDetail"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentJournalDetail(IntPtr pointer) : base(pointer)
         {
         }

--- a/RemoteAgents/AgentVoteMVP.cs
+++ b/RemoteAgents/AgentVoteMVP.cs
@@ -16,26 +16,53 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Player MVP voting system (typically seen at the end of duties).
+    /// Manages the list of eligible players and facilitates the voting process.
+    /// </summary>
     public class AgentVoteMVP : AgentInterface<AgentVoteMVP>, IAgent
     {
         private static readonly LLogger Log = new(nameof(AgentVoteMVP), Colors.Gold);
+
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentVoteMVPOffsets.VTable;
 
+        /// <summary>
+        /// Gets the window control for the MVP notification popup.
+        /// </summary>
         public static AtkAddonControl? NotificationWindow => RaptureAtkUnitManager.GetWindowByName("_NotificationIcMvp", true);
 
-        
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentVoteMVP"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentVoteMVP(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Gets the number of players eligible to receive an MVP vote.
+        /// </summary>
         public int PlayerCount => Core.Memory.NoCacheRead<int>(Pointer + AgentVoteMVPOffsets.PlayerCount);
+
+        /// <summary>
+        /// Gets the memory pointer to the start of the <see cref="VoteOption"/> array.
+        /// </summary>
         public IntPtr ArrayStart => Core.Memory.NoCacheRead<IntPtr>(Pointer + AgentVoteMVPOffsets.ArrayStart);
 
+        /// <summary>
+        /// Gets an array of <see cref="VoteOption"/> objects representing the players available for voting.
+        /// </summary>
         public VoteOption[] VoteOptions => Core.Memory.ReadArray<VoteOption>(ArrayStart, PlayerCount);
 
+        /// <summary>
+        /// Gets a value indicating whether the vote window can currently be toggled (i.e., the notification popup is visible).
+        /// </summary>
         public bool CanToggle => NotificationWindow is { IsVisible: true };
 
+        /// <summary>
+        /// Attempts to open the MVP voting window if it is not already open.
+        /// </summary>
         public void OpenVoteWindow()
         {
             if (VoteMvp.Instance.IsOpen)
@@ -49,6 +76,11 @@ namespace LlamaLibrary.RemoteAgents
             }
         }
 
+        /// <summary>
+        /// Ensures that the MVP voting window is open and contains at least one player.
+        /// Toggles the window if necessary and waits for the UI to populate.
+        /// </summary>
+        /// <returns><see langword="true"/> if the window is open and ready; otherwise <see langword="false"/>.</returns>
         public async Task<bool> MakeSureVoteOpen()
         {
             if (VoteMvp.Instance.IsOpen)
@@ -70,6 +102,11 @@ namespace LlamaLibrary.RemoteAgents
             return VoteMvp.Instance.IsOpen && PlayerCount > 0;
         }
 
+        /// <summary>
+        /// Ensures the vote window is open and casts a vote for the player at the specified index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the player to vote for. Will be clamped to the available player count.</param>
+        /// <returns><see langword="true"/> if the vote was successfully cast and the window closed; otherwise <see langword="false"/>.</returns>
         public async Task<bool> OpenAndVote(int index = 0)
         {
             if (!await MakeSureVoteOpen())
@@ -82,6 +119,11 @@ namespace LlamaLibrary.RemoteAgents
             return await Coroutine.Wait(10000, () => !VoteMvp.Instance.IsOpen);
         }
 
+        /// <summary>
+        /// Ensures the vote window is open, casts a vote for the player at the specified index, and returns their name.
+        /// </summary>
+        /// <param name="index">The zero-based index of the player to vote for.</param>
+        /// <returns>The name of the player who received the vote, or an empty string if the operation failed.</returns>
         public async Task<string> OpenAndVoteName(int index = 0)
         {
             if (!await MakeSureVoteOpen())
@@ -97,6 +139,13 @@ namespace LlamaLibrary.RemoteAgents
             return name;
         }
 
+        /// <summary>
+        /// Attempts to cast an MVP vote based on a list of preferred names.
+        /// Votes for the first player whose name matches (case-insensitive) any entry in <paramref name="possibleNames"/>.
+        /// If no matches are found or the list is empty, votes for the first available player.
+        /// </summary>
+        /// <param name="possibleNames">A collection of names to prioritize for voting.</param>
+        /// <returns>The name of the player who received the vote, or an empty string if no vote was cast.</returns>
         public async Task<string> HandleMvpVote(IEnumerable<string> possibleNames)
         {
             var enumerable = possibleNames.ToList();
@@ -156,20 +205,39 @@ Log.Information($"点赞结束");
         }
     }
 
+    /// <summary>
+    /// Represents a player option in the MVP voting window.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 0x78)]
     public struct VoteOption
     {
+        /// <summary>
+        /// The memory pointer to the player's name string.
+        /// </summary>
         [FieldOffset(0x0)]
         public IntPtr NamePtr;
 
+        /// <summary>
+        /// The length of the player's name string.
+        /// </summary>
         [FieldOffset(0x10)]
         public int NameLength;
 
+        /// <summary>
+        /// The player's current <see cref="ClassJobType"/>.
+        /// </summary>
         [FieldOffset(0x70)]
         public ClassJobType Job;
 
+        /// <summary>
+        /// Gets the player's name by reading from <see cref="NamePtr"/>.
+        /// </summary>
         public string Name => Core.Memory.ReadString(NamePtr, Encoding.UTF8, NameLength);
 
+        /// <summary>
+        /// Returns a string representation of the vote option.
+        /// </summary>
+        /// <returns>A string containing the job and name.</returns>
         public override string ToString()
         {
             return $"Job: {Job}, Name: {Name}";


### PR DESCRIPTION
Added comprehensive XML documentation for several classes in the RemoteAgents namespace to improve maintainability and clarity.

Key changes:
- Documented AgentVoteMVP.cs, including its methods for ensuring the vote window is open and casting votes, and the VoteOption struct.
- Documented AgentAWGrowthFragTrade.cs, providing details on the Anima Weapon Crystal Sand exchange logic and the BuyCrystalSand method.
- Added baseline documentation for sparse agent classes: AgentContentsInfo, AgentJournalDetail, AgentItemAppraisal, AgentAchievement, and AgentFateProgress.

All changes verified via 'dotnet build' to ensure no new warnings were introduced.

---
*PR created automatically by Jules for task [9188964027126166832](https://jules.google.com/task/9188964027126166832) started by @nt153133*