### PR TITLE
📝 Scribe: Add XML documentation for AgentHandIn, AgentDawn, and AgentTradeMultiple

### DIFF
--- a/RemoteAgents/AgentDawn.cs
+++ b/RemoteAgents/AgentDawn.cs
@@ -6,15 +6,26 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the "Dawn" (Trust / Duty Support) system interface.
+    /// Manages selection and state of NPCs for NPC-assisted duties.
+    /// </summary>
     public class AgentDawn : AgentInterface<AgentDawn>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentDawnOffsets.DawnVtable;
-        
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentDawn"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentDawn(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Gets or sets the ID of the currently selected Trust/Duty Support NPC or content row.
+        /// </summary>
         public int TrustId
         {
             get => Core.Memory.Read<byte>(Pointer + AgentDawnOffsets.DawnTrustId);

--- a/RemoteAgents/AgentHandIn.cs
+++ b/RemoteAgents/AgentHandIn.cs
@@ -7,15 +7,27 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the item hand-in interface (e.g., for Grand Company deliveries or quest turn-ins).
+    /// Facilitates the selection and submission of items from the player's inventory.
+    /// </summary>
     public class AgentHandIn : AgentInterface<AgentHandIn>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentHandInOffsets.VTable;
-        
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentHandIn"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentHandIn(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Executes the hand-in action for a specific item slot.
+        /// </summary>
+        /// <param name="slot">The <see cref="BagSlot"/> containing the item to be handed in.</param>
         public void HandIn(BagSlot slot)
         {
             Core.Memory.CallInjectedWraper<uint>(

--- a/RemoteAgents/AgentTradeMultiple.cs
+++ b/RemoteAgents/AgentTradeMultiple.cs
@@ -4,10 +4,18 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents;
 
-public class AgentTradeMultiple: AgentInterface<AgentTradeMultiple>, IAgent
+/// <summary>
+/// Remote agent for managing multi-item trade interfaces (e.g., trading multiple items to an NPC for a single reward).
+/// </summary>
+public class AgentTradeMultiple : AgentInterface<AgentTradeMultiple>, IAgent
 {
+    /// <inheritdoc/>
     public IntPtr RegisteredVtable => PlatypusOffsets.AgentTradeMultiple;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentTradeMultiple"/> class.
+    /// </summary>
+    /// <param name="pointer">The memory address of the agent.</param>
     protected AgentTradeMultiple(IntPtr pointer) : base(pointer)
     {
     }


### PR DESCRIPTION
Identified and addressed missing XML documentation in three key RemoteAgent classes: `AgentHandIn`, `AgentDawn`, and `AgentTradeMultiple`. 

### Changes
- **AgentHandIn.cs**: Added summaries for the class, constructor, and `HandIn` method, highlighting its role in inventory submission.
- **AgentDawn.cs**: Added documentation for the Trust/Duty Support system interface and the `TrustId` property.
- **AgentTradeMultiple.cs**: Added class-level documentation for multi-item trade management.

Verified the changes with `dotnet build` to ensure no new XML warnings or syntax errors were introduced.

---
*PR created automatically by Jules for task [4066428752661537817](https://jules.google.com/task/4066428752661537817) started by @nt153133*