### PR TITLE
📝 Scribe: Add XML documentation for MJI Agents and JSON Models

### DIFF
--- a/JsonObjects/CustomDeliveryNpc.cs
+++ b/JsonObjects/CustomDeliveryNpc.cs
@@ -1,22 +1,48 @@
-﻿using Clio.Utilities;
+using Clio.Utilities;
 using Newtonsoft.Json;
 
 namespace LlamaLibrary.JsonObjects
 {
+    /// <summary>
+    /// Represents metadata for a Custom Delivery NPC, typically loaded from embedded resources.
+    /// </summary>
     public class CustomDeliveryNpc
     {
+        /// <summary>The ENpcResident identifier of the NPC.</summary>
         public uint npcId;
+
+        /// <summary>The TerritoryType (zone) identifier where the NPC is located.</summary>
         public uint Zone;
+
+        /// <summary>The world coordinates for the NPC's location.</summary>
         public Vector3 Location;
+
+        /// <summary>The display name of the NPC.</summary>
         public string Name;
+
+        /// <summary>The Quest identifier required to unlock this NPC's deliveries.</summary>
         public int RequiredQuest;
+
+        /// <summary>The internal index or order of the NPC within the custom delivery system.</summary>
         public uint Index;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomDeliveryNpc"/> class for JSON deserialization.
+        /// </summary>
         [JsonConstructor]
         public CustomDeliveryNpc()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomDeliveryNpc"/> class with specific data.
+        /// </summary>
+        /// <param name="npcId">The ENpcResident identifier.</param>
+        /// <param name="zone">The zone identifier.</param>
+        /// <param name="location">The world coordinates.</param>
+        /// <param name="name">The NPC's name.</param>
+        /// <param name="requiredQuest">The unlock quest ID.</param>
+        /// <param name="index">The system index.</param>
         public CustomDeliveryNpc(uint npcId, uint zone, Vector3 location, string name, int requiredQuest, uint index)
         {
             this.npcId = npcId;

--- a/JsonObjects/GCShopItemStored.cs
+++ b/JsonObjects/GCShopItemStored.cs
@@ -1,20 +1,36 @@
-﻿using System;
+using System;
 using LlamaLibrary.Helpers;
 
 namespace LlamaLibrary.JsonObjects
 {
+    /// <summary>
+    /// Represents an item available for purchase from a Grand Company shop, typically loaded from embedded resources.
+    /// </summary>
     public class GCShopItemStored : IEquatable<GCShopItemStored>
     {
+        /// <summary>Gets or sets the numeric identifier of the item.</summary>
         public uint ItemId { get; set; }
+
+        /// <summary>Gets or sets the cost of the item in Grand Company seals.</summary>
         public int Cost { get; set; }
+
+        /// <summary>Gets or sets the Grand Company rank required to purchase this item.</summary>
         public uint RequiredRank { get; set; }
+
+        /// <summary>Gets or sets the rank group (tier) this item belongs to within the GC shop.</summary>
         public byte GCRankGroup { get; set; }
+
+        /// <summary>Gets or sets the category under which this item is listed in the shop interface.</summary>
         public GCShopCategory Category { get; set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GCShopItemStored"/> class for JSON deserialization.
+        /// </summary>
         public GCShopItemStored()
         {
         }
 
+        /// <inheritdoc/>
         public bool Equals(GCShopItemStored? other)
         {
             if (other is null)
@@ -30,6 +46,7 @@ namespace LlamaLibrary.JsonObjects
             return ItemId == other.ItemId && Cost == other.Cost && RequiredRank == other.RequiredRank && GCRankGroup == other.GCRankGroup && Category == other.Category;
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is null)
@@ -50,6 +67,7 @@ namespace LlamaLibrary.JsonObjects
             return Equals((GCShopItemStored)obj);
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked
@@ -63,6 +81,14 @@ namespace LlamaLibrary.JsonObjects
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GCShopItemStored"/> class with specific data.
+        /// </summary>
+        /// <param name="itemId">The item identifier.</param>
+        /// <param name="cost">The seal cost.</param>
+        /// <param name="requiredRank">The required GC rank ID.</param>
+        /// <param name="gcRankGroup">The rank group tier.</param>
+        /// <param name="category">The shop category.</param>
         public GCShopItemStored(uint itemId, int cost, uint requiredRank, byte gcRankGroup, GCShopCategory category)
         {
             ItemId = itemId;

--- a/JsonObjects/MateriaItem.cs
+++ b/JsonObjects/MateriaItem.cs
@@ -1,17 +1,37 @@
-﻿using ff14bot.Managers;
+using ff14bot.Managers;
 
 namespace LlamaLibrary.JsonObjects
 {
+    /// <summary>
+    /// Represents data for a specific materia item, typically loaded from embedded resources.
+    /// </summary>
     public class MateriaItem
     {
+        /// <summary>The numeric identifier (Item ID) of the materia.</summary>
         public int Key;
+
+        /// <summary>The tier of the materia (e.g., I=1, X=10).</summary>
         public int Tier;
+
+        /// <summary>The value of the stat bonus provided by the materia.</summary>
         public int Value;
+
+        /// <summary>Gets the <see cref="Item"/> data for this materia from the game's DataManager.</summary>
         internal Item Item => DataManager.GetItem((uint)Key);
+
+        /// <summary>Gets the localized name of the materia item.</summary>
         public string ItemName => Item.CurrentLocaleName;
 
+        /// <summary>The name of the stat this materia enhances (e.g., "Critical Hit").</summary>
         public string Stat;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MateriaItem"/> class.
+        /// </summary>
+        /// <param name="key">The Item ID.</param>
+        /// <param name="tier">The materia tier.</param>
+        /// <param name="value">The stat bonus value.</param>
+        /// <param name="stat">The name of the enhanced stat.</param>
         public MateriaItem(int key, int tier, int value, string stat)
         {
             Key = key;
@@ -20,6 +40,7 @@ namespace LlamaLibrary.JsonObjects
             Stat = stat;
         }
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return $"{DataManager.GetItem((uint)Key).CurrentLocaleName} {Tier} {Value}";

--- a/RemoteAgents/AgentMJIGatheringNoteBook.cs
+++ b/RemoteAgents/AgentMJIGatheringNoteBook.cs
@@ -1,16 +1,22 @@
-﻿using System;
+using System;
 using ff14bot.Managers;
-using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Island Sanctuary (MJI) gathering notebook interface.
+    /// Manages the data for the log of materials that can be gathered within the Island Sanctuary.
+    /// </summary>
     public class AgentMJIGatheringNoteBook : AgentInterface<AgentMJIGatheringNoteBook>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentMJIGatheringNoteBookOffsets.VTable;
 
-        
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentMJIGatheringNoteBook"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentMJIGatheringNoteBook(IntPtr pointer) : base(pointer)
         {
         }

--- a/RemoteAgents/AgentMJIHud.cs
+++ b/RemoteAgents/AgentMJIHud.cs
@@ -1,22 +1,35 @@
-﻿using System;
+using System;
 using ff14bot;
 using ff14bot.Managers;
-using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Island Sanctuary (MJI) HUD interface.
+    /// Provides access to core progression data like current experience points.
+    /// </summary>
     public class AgentMJIHud : AgentInterface<AgentMJIHud>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentMJIHudOffsets.VTable;
 
-        
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentMJIHud"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentMJIHud(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Gets the memory pointer to the Island Sanctuary information block.
+        /// </summary>
         public IntPtr InfoPtr => Core.Memory.Read<IntPtr>(Pointer + AgentMJIHudOffsets.InfoPtr);
+
+        /// <summary>
+        /// Gets the player's current experience points within the Island Sanctuary.
+        /// </summary>
         public uint CurrentExp => Core.Memory.Read<uint>(InfoPtr + AgentMJIHudOffsets.CurrentExp);
     }
 }

--- a/RemoteAgents/AgentMJIPouch.cs
+++ b/RemoteAgents/AgentMJIPouch.cs
@@ -1,16 +1,22 @@
-﻿using System;
+using System;
 using ff14bot.Managers;
-using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Island Sanctuary (MJI) pouch interface.
+    /// Handles data and logic for the specialized inventory used within the Island Sanctuary.
+    /// </summary>
     public class AgentMJIPouch : AgentInterface<AgentMJIPouch>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentMJIPouchOffsets.VTable;
 
-        
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentMJIPouch"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentMJIPouch(IntPtr pointer) : base(pointer)
         {
         }

--- a/RemoteAgents/AgentMJIRecipeNoteBook.cs
+++ b/RemoteAgents/AgentMJIRecipeNoteBook.cs
@@ -1,16 +1,22 @@
-﻿using System;
+using System;
 using ff14bot.Managers;
-using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Island Sanctuary (MJI) recipe notebook interface.
+    /// Manages the data for crafting recipes available within the Island Sanctuary.
+    /// </summary>
     public class AgentMJIRecipeNoteBook : AgentInterface<AgentMJIRecipeNoteBook>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentMJIRecipeNoteBookOffsets.VTable;
 
-        
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentMJIRecipeNoteBook"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentMJIRecipeNoteBook(IntPtr pointer) : base(pointer)
         {
         }


### PR DESCRIPTION
💡 **What:** Added XML documentation to Island Sanctuary (MJI) remote agents and core JSON data models.

🎯 **Why:** These areas were previously undocumented, making it difficult for developers to understand the purpose of specific fields (like `Index` vs `npcId`) and the role of specialized MJI agents.

🔬 **Examples:**
```csharp
/// <summary>
/// Remote agent for the Island Sanctuary (MJI) HUD interface.
/// Provides access to core progression data like current experience points.
/// </summary>
public class AgentMJIHud : AgentInterface<AgentMJIHud>, IAgent
```

---
*PR created automatically by Jules for task [6456979539843058030](https://jules.google.com/task/6456979539843058030) started by @nt153133*