### PR TITLE
📝 Scribe: Add XML documentation for RemoteAgents

### DIFF
--- a/RemoteAgents/AgentBankaCraftworksSupply.cs
+++ b/RemoteAgents/AgentBankaCraftworksSupply.cs
@@ -6,26 +6,39 @@ using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.RemoteAgents;
 
-
+/// <summary>
+/// Remote agent for the Banka Craftworks item supply interface.
+/// Manages the submission of crafted or gathered items for Banka Craftworks.
+/// </summary>
 public class AgentBankaCraftworksSupply : AgentInterface<AgentBankaCraftworksSupply>, IAgent
 {
-
-
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentBankaCraftworksSupply"/> class.
+    /// </summary>
+    /// <param name="pointer">The memory address of the agent.</param>
     protected AgentBankaCraftworksSupply(IntPtr pointer) : base(pointer)
     {
     }
 
+    /// <inheritdoc/>
     public IntPtr RegisteredVtable => AgentBankaCraftworksSupplyOffsets.Vtable;
 
+    /// <summary>
+    /// Gets the memory address of the internal instance pointer.
+    /// </summary>
     public IntPtr InstancePointer
     {
         get
         {
-            var temp1 = Core.Memory.Read<IntPtr>(Pointer ) ;
+            var temp1 = Core.Memory.Read<IntPtr>(Pointer);
             return temp1;
         }
     }
 
+    /// <summary>
+    /// Gets the memory address of the internal function pointer used for item hand-ins,
+    /// resolved by reading an offset from the main instance pointer.
+    /// </summary>
     public IntPtr InstancePointerWithOffset
     {
         get
@@ -35,6 +48,10 @@ public class AgentBankaCraftworksSupply : AgentInterface<AgentBankaCraftworksSup
         }
     }
 
+    /// <summary>
+    /// Executes the hand-in operation for a specified item in a bag slot.
+    /// </summary>
+    /// <param name="slot">The <see cref="BagSlot"/> containing the item to hand in.</param>
     public void HandIn(BagSlot slot)
     {
         //var instance = Core.Memory.Read<IntPtr>(Pointer) + Offsets.PointerOffset;

--- a/RemoteAgents/AgentDawnStory.cs
+++ b/RemoteAgents/AgentDawnStory.cs
@@ -7,14 +7,23 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the "Dawn Story" (Duty Support story mode) interface.
+    /// Manages the selection and availability of duties in the story mode Duty Support window.
+    /// </summary>
     public class AgentDawnStory : AgentInterface<AgentDawnStory>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentDawnStoryOffsets.Vtable;
 
-        
-
+        /// <summary>
+        /// Gets a value indicating whether the duty list has been fully loaded into memory.
+        /// </summary>
         public bool IsLoaded => Core.Memory.Read<byte>(Pointer + AgentDawnStoryOffsets.Loaded) != 0;
 
+        /// <summary>
+        /// Gets the memory pointer to the start of the duty information array.
+        /// </summary>
         public IntPtr DutyArrayPtr
         {
             get
@@ -25,12 +34,22 @@ namespace LlamaLibrary.RemoteAgents
             }
         }
 
+        /// <summary>
+        /// Gets an array of <see cref="DutyInfo"/> structures representing the available story duties.
+        /// </summary>
         public DutyInfo[] Duties => Core.Memory.ReadArray<DutyInfo>(DutyArrayPtr, AgentDawnStoryOffsets.DutyCount);
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentDawnStory"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentDawnStory(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Gets the identifier of the currently selected duty in the interface.
+        /// </summary>
         public byte SelectedDuty => Core.Memory.Read<byte>(Pointer + 0x28);
     }
 }

--- a/RemoteAgents/AgentLookingForGroup.cs
+++ b/RemoteAgents/AgentLookingForGroup.cs
@@ -7,18 +7,31 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Party Finder (Looking for Group) interface.
+    /// Manages recruitment comments and other PF-related settings.
+    /// </summary>
     public class AgentLookingForGroup : AgentInterface<AgentLookingForGroup>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentLookingForGroupOffsets.VTable;
 
-        
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentLookingForGroup"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentLookingForGroup(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Gets the memory address where the Party Finder recruitment comment is stored.
+        /// </summary>
         public IntPtr CommentStringPtr => Pointer + AgentLookingForGroupOffsets.CommentString;
 
+        /// <summary>
+        /// Gets or sets the Party Finder recruitment comment string.
+        /// </summary>
         public string SavedComment
         {
             get => Core.Memory.ReadStringUTF8(CommentStringPtr);

--- a/RemoteAgents/AgentMinionNoteBook.cs
+++ b/RemoteAgents/AgentMinionNoteBook.cs
@@ -9,17 +9,32 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Minion Guide (Minion Notebook) interface.
+    /// Provides access to the list of acquired minions and their metadata.
+    /// </summary>
     public class AgentMinionNoteBook : AgentInterface<AgentMinionNoteBook>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentMinionNoteBookOffsets.VTable;
 
+        /// <summary>
+        /// Gets the memory address where the pointer to the minion list is stored.
+        /// </summary>
         public IntPtr MinionListAddress => Pointer + AgentMinionNoteBookOffsets.AgentOffset;
-        
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentMinionNoteBook"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentMinionNoteBook(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Retrieves the full list of minions currently loaded in the agent's memory.
+        /// </summary>
+        /// <returns>An array of <see cref="MinionStruct"/> objects.</returns>
         public MinionStruct[] GetCurrentMinions()
         {
             var address = Pointer + AgentMinionNoteBookOffsets.AgentOffset;
@@ -28,6 +43,11 @@ namespace LlamaLibrary.RemoteAgents
             return Core.Memory.ReadArray<MinionStruct>(address1, (int)count);
         }
 
+        /// <summary>
+        /// Retrieves the localized name of a minion by its index in the guide.
+        /// </summary>
+        /// <param name="index">The zero-based index of the minion.</param>
+        /// <returns>The minion name as a string, or an empty string if not found.</returns>
         public static string GetMinionName(int index)
         {
             var result = Core.Memory.CallInjectedWraper<IntPtr>(AgentMinionNoteBookOffsets.GetCompanion, index);
@@ -35,12 +55,21 @@ namespace LlamaLibrary.RemoteAgents
         }
     }
 
+    /// <summary>
+    /// Represents the memory-mapped structure for a minion in the guide.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 0x4)]
     public struct MinionStruct
     {
+        /// <summary>
+        /// The unique identifier of the minion.
+        /// </summary>
         [FieldOffset(0)]
         public ushort MinionId;
 
+        /// <summary>
+        /// Reserved or unknown field.
+        /// </summary>
         [FieldOffset(2)]
         public ushort unknown;
     }


### PR DESCRIPTION
💡 **What:** Added XML documentation for `AgentLookingForGroup`, `AgentBankaCraftworksSupply`, `AgentDawnStory`, and `AgentMinionNoteBook` classes, including their properties and methods.
🎯 **Why:** These classes interface directly with game memory and UI but lacked clear documentation on their purpose and member behavior, making maintenance and usage difficult for other developers.
🔬 **Examples:**
`AgentLookingForGroup` now clearly describes its role in managing Party Finder recruitment comments.
`AgentBankaCraftworksSupply` documents its nested memory structure for item hand-ins.

---
*PR created automatically by Jules for task [16360430135097235854](https://jules.google.com/task/16360430135097235854) started by @nt153133*