### PR TITLE
📝 Scribe: Add XML documentation for Free Company, LFG, and OutOnLimb Agents

### DIFF
--- a/RemoteAgents/AgentFreeCompany.cs
+++ b/RemoteAgents/AgentFreeCompany.cs
@@ -11,16 +11,28 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Free Company interface.
+    /// Manages information about the Free Company, including member roster and active/available company actions.
+    /// </summary>
     //TODO This agent has way too many hardcoded memory offsets
     public class AgentFreeCompany : AgentInterface<AgentFreeCompany>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentFreeCompanyOffsets.VTable;
 
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentFreeCompany"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentFreeCompany(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Gets the memory pointer to the Free Company member roster.
+        /// </summary>
+        /// <returns>A pointer to the roster data.</returns>
         public IntPtr GetRosterPtr()
         {
             var ptr1 = Core.Memory.Read<IntPtr>(Pointer + 0x48);
@@ -29,6 +41,10 @@ namespace LlamaLibrary.RemoteAgents
             return ptr2;
         }
 
+        /// <summary>
+        /// Retrieves the list of Free Company members and their current online status from game memory.
+        /// </summary>
+        /// <returns>A list of tuples containing member names and their online status.</returns>
         public List<(string Name, bool Online)> GetMembers()
         {
             var i = 0;
@@ -51,9 +67,16 @@ namespace LlamaLibrary.RemoteAgents
             return result;
         }
 
+        /// <summary>
+        /// Gets the number of lines in the Free Company history log.
+        /// </summary>
         [Obsolete("Not sure what's using this but pattern is returning multiple values")]
         public byte HistoryLineCount => Core.Memory.Read<byte>(Pointer + AgentFreeCompanyOffsets.HistoryCount);
 
+        /// <summary>
+        /// Gets the memory address where the Free Company action data is stored.
+        /// Resolved through a series of offsets from the AtkStage.
+        /// </summary>
         public IntPtr ActionAddress
         {
             get
@@ -67,6 +90,11 @@ namespace LlamaLibrary.RemoteAgents
             }
         }
 
+        /// <summary>
+        /// Retrieves the Free Company actions that are currently active (buffs).
+        /// Opens the Free Company interface if it is not already open.
+        /// </summary>
+        /// <returns>An array of <see cref="FcAction"/> structures representing active actions.</returns>
         public async Task<FcAction[]> GetCurrentActions()
         {
             var wasopen = FreeCompany.Instance.IsOpen;
@@ -96,6 +124,11 @@ namespace LlamaLibrary.RemoteAgents
             return new FcAction[0];
         }
 
+        /// <summary>
+        /// Retrieves the list of available Free Company actions that have been purchased or unlocked.
+        /// Opens the Free Company interface if it is not already open.
+        /// </summary>
+        /// <returns>An array of <see cref="FcAction"/> structures representing available actions.</returns>
         public async Task<FcAction[]> GetAvailableActions()
         {
             var wasopen = FreeCompany.Instance.IsOpen;
@@ -126,11 +159,19 @@ namespace LlamaLibrary.RemoteAgents
         }
     }
 
+    /// <summary>
+    /// Represents a Free Company action (buff).
+    /// </summary>
     [StructLayout(LayoutKind.Sequential, Size = 0xC)]
     public struct FcAction
     {
+        /// <summary>The unique identifier of the action.</summary>
         public uint id;
+
+        /// <summary>The icon identifier associated with the action.</summary>
         public uint iconId;
+
+        /// <summary>An unknown field, possibly a status or timestamp.</summary>
         public uint unk;
     }
 }

--- a/RemoteAgents/AgentLookingForGroup.cs
+++ b/RemoteAgents/AgentLookingForGroup.cs
@@ -7,18 +7,31 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the "Looking for Group" (Party Finder) interface.
+    /// Manages the recruitment comment for the local player's party or search.
+    /// </summary>
     public class AgentLookingForGroup : AgentInterface<AgentLookingForGroup>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentLookingForGroupOffsets.VTable;
 
-        
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentLookingForGroup"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentLookingForGroup(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Gets the memory pointer to the recruitment comment string.
+        /// </summary>
         public IntPtr CommentStringPtr => Pointer + AgentLookingForGroupOffsets.CommentString;
 
+        /// <summary>
+        /// Gets or sets the recruitment comment displayed in the Party Finder.
+        /// </summary>
         public string SavedComment
         {
             get => Core.Memory.ReadStringUTF8(CommentStringPtr);

--- a/RemoteAgents/AgentOutOnLimb.cs
+++ b/RemoteAgents/AgentOutOnLimb.cs
@@ -7,26 +7,47 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the "Out on a Limb" and "Finer Miner" (Logging and Mining) mini-games.
+    /// Manages the game state, including cursor position, double-down availability, and readiness status.
+    /// </summary>
     public class AgentOutOnLimb : AgentInterface<AgentOutOnLimb>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentOutOnLimbOffsets.VTable;
 
-
+        /// <summary>
+        /// The memory address where the current cursor location value is stored.
+        /// </summary>
         public IntPtr addressLocation = IntPtr.Zero;
+
         private readonly Random rnd = new();
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentOutOnLimb"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentOutOnLimb(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Gets the number of double-down opportunities remaining in the current session.
+        /// </summary>
         public int DoubleDownRemaining => Core.Memory.Read<byte>(Pointer + AgentOutOnLimbOffsets.DoubleDownRemaining);
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the mini-game cursor is currently locked.
+        /// </summary>
         public bool CursorLocked
         {
             get => Core.Memory.Read<byte>(Pointer + AgentOutOnLimbOffsets.CursorLocked) != 1;
             set => Core.Memory.Write(Pointer + AgentOutOnLimbOffsets.CursorLocked, (byte)(value ? 0 : 1));
         }
 
+        /// <summary>
+        /// Gets or sets the current horizontal position of the mini-game cursor.
+        /// </summary>
         [Obsolete("Use Director Instead")]
         public int CursorLocation
         {
@@ -34,10 +55,20 @@ namespace LlamaLibrary.RemoteAgents
             set => Core.Memory.Write(addressLocation, LocationValue(value));
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the Botanist (Logging) mini-game is ready to play.
+        /// </summary>
         public bool IsReadyBotanist => Core.Memory.NoCacheRead<byte>(Pointer + AgentOutOnLimbOffsets.IsReady) == 3;
 
+        /// <summary>
+        /// Gets a value indicating whether the Miner (Aming) mini-game is ready to play.
+        /// </summary>
         public bool IsReadyAimg => Core.Memory.NoCacheRead<byte>(Pointer + AgentOutOnLimbOffsets.IsReady) == 2;
 
+        /// <summary>
+        /// Refreshes the <see cref="addressLocation"/> by resolving it from the game's number array data.
+        /// Must be called when the mini-game starts or the UI updates.
+        /// </summary>
         public void Refresh()
         {
             var numArray = AtkArrayDataHolder.NumberArray(104);


### PR DESCRIPTION
💡 **What:** 
Added XML triple-slash documentation to three key remote agent classes in the `RemoteAgents` namespace:
- `AgentFreeCompany.cs`: Added documentation for the agent class, roster retrieval, company actions, and the `FcAction` struct.
- `AgentLookingForGroup.cs`: Documented the Party Finder recruitment comment management.
- `AgentOutOnLimb.cs`: Added details for the Gold Saucer logging/mining mini-games state management.

🎯 **Why:** 
These classes interface directly with game memory and UI, but lacked clear documentation for their members. Adding XML comments improves maintainability and makes the internal workings of these agents transparent to future developers.

🔬 **Examples:**
```csharp
/// <summary>
/// Retrieves the Free Company actions that are currently active (buffs).
/// Opens the Free Company interface if it is not already open.
/// </summary>
/// <returns>An array of FcAction structures representing active actions.</returns>
public async Task<FcAction[]> GetCurrentActions()
```

---
*PR created automatically by Jules for task [16373776405943599050](https://jules.google.com/task/16373776405943599050) started by @nt153133*