### PR TITLE
📝 Scribe: Add XML documentation for Remote Agents

### DIFF
--- a/RemoteAgents/AgentBankaCraftworksSupply.cs
+++ b/RemoteAgents/AgentBankaCraftworksSupply.cs
@@ -7,25 +7,39 @@ using LlamaLibrary.Utilities;
 namespace LlamaLibrary.RemoteAgents;
 
 
+/// <summary>
+/// Remote agent for the Banka Craftworks item submission interface.
+/// Facilitates the hand-in of crafted items for the Banka Craftworks system.
+/// </summary>
 public class AgentBankaCraftworksSupply : AgentInterface<AgentBankaCraftworksSupply>, IAgent
 {
-
-
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentBankaCraftworksSupply"/> class.
+    /// </summary>
+    /// <param name="pointer">The memory address of the agent.</param>
     protected AgentBankaCraftworksSupply(IntPtr pointer) : base(pointer)
     {
     }
 
+    /// <inheritdoc/>
     public IntPtr RegisteredVtable => AgentBankaCraftworksSupplyOffsets.Vtable;
 
+    /// <summary>
+    /// Gets the memory pointer to the primary instance of the craftworks supply data.
+    /// </summary>
     public IntPtr InstancePointer
     {
         get
         {
-            var temp1 = Core.Memory.Read<IntPtr>(Pointer ) ;
+            var temp1 = Core.Memory.Read<IntPtr>(Pointer);
             return temp1;
         }
     }
 
+    /// <summary>
+    /// Gets the memory pointer to the craftworks supply data, adjusted by the system-defined offset.
+    /// Used as the target for the hand-in function call.
+    /// </summary>
     public IntPtr InstancePointerWithOffset
     {
         get
@@ -35,6 +49,10 @@ public class AgentBankaCraftworksSupply : AgentInterface<AgentBankaCraftworksSup
         }
     }
 
+    /// <summary>
+    /// Hands in the specified <see cref="BagSlot"/> to the Banka Craftworks interface.
+    /// </summary>
+    /// <param name="slot">The inventory slot containing the item to be handed in.</param>
     public void HandIn(BagSlot slot)
     {
         //var instance = Core.Memory.Read<IntPtr>(Pointer) + Offsets.PointerOffset;

--- a/RemoteAgents/AgentFishGuide2.cs
+++ b/RemoteAgents/AgentFishGuide2.cs
@@ -10,38 +10,82 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the fishing guide (log) interface.
+    /// Provides access to the player's fishing history, including which fish have been caught.
+    /// </summary>
     public class AgentFishGuide2 : AgentInterface<AgentFishGuide2>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentFishGuide2Offsets.Vtable;
 
+        /// <summary>
+        /// The total number of tabs in the fishing guide.
+        /// </summary>
         public const int TabCount = 37;
 
-        
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentFishGuide2"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentFishGuide2(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Gets the memory pointer to the fishing guide's information block.
+        /// </summary>
         public IntPtr InfoPointer => Core.Memory.Read<IntPtr>(Pointer + AgentFishGuide2Offsets.InfoOffset);
 
+        /// <summary>
+        /// Gets the memory pointer to the beginning of the fish list array.
+        /// </summary>
         public IntPtr StartingPointer => Core.Memory.Read<IntPtr>(InfoPointer + AgentFishGuide2Offsets.StartingPointer);
 
+        /// <summary>
+        /// Gets the memory pointer to the end of the fish list array.
+        /// </summary>
         public IntPtr EndingPointer => Core.Memory.Read<IntPtr>(InfoPointer + AgentFishGuide2Offsets.EndingPointer);
 
+        /// <summary>
+        /// Gets the memory pointer to a specific position in the fish list array.
+        /// </summary>
+        /// <param name="start">The zero-based index to start from.</param>
+        /// <returns>An <see cref="IntPtr"/> to the specified fish list entry.</returns>
         public IntPtr FishListPointer(int start = 0) => Core.Memory.Read<IntPtr>(StartingPointer + (8 * start));
 
+        /// <summary>
+        /// Gets the total number of fish entries (slots) available in the current fishing guide view.
+        /// </summary>
         public int SlotCount => (int)((EndingPointer.ToInt64() - StartingPointer.ToInt64()) / 8);
 
+        /// <summary>
+        /// Retrieves the entire fish list from game memory.
+        /// </summary>
+        /// <returns>An array of <see cref="FishGuide2Item"/> structures.</returns>
         public FishGuide2Item[] GetFishListRaw()
         {
             return Core.Memory.ReadArray<FishGuide2Item>(Core.Memory.Read<IntPtr>(StartingPointer), SlotCount); //.Select(x => x.FishItem) as List<uint>;
         }
 
+        /// <summary>
+        /// Retrieves a portion of the fish list from game memory.
+        /// </summary>
+        /// <param name="start">The index of the first item to retrieve.</param>
+        /// <param name="count">The number of items to retrieve.</param>
+        /// <returns>An array of <see cref="FishGuide2Item"/> structures.</returns>
         public FishGuide2Item[] GetFishListRaw(int start, int count)
         {
             return Core.Memory.ReadArray<FishGuide2Item>(FishListPointer(start), count); //.Select(x => x.FishItem) as List<uint>;
         }
 
+        /// <summary>
+        /// Opens the fishing guide UI and retrieves the fish list.
+        /// Handles UI navigation to ensure the correct tab and mode are selected.
+        /// </summary>
+        /// <param name="start">The index of the first item to retrieve.</param>
+        /// <param name="count">The number of items to retrieve. If 0, retrieves all items up to <see cref="SlotCount"/>.</param>
+        /// <returns>An array of <see cref="FishGuide2Item"/> structures, or an empty array if the UI could not be opened.</returns>
         public async Task<FishGuide2Item[]> GetFishList(int start = 0, int count = 0)
         {
             if (!FishGuide2.Instance.IsOpen)
@@ -71,35 +115,57 @@ namespace LlamaLibrary.RemoteAgents
         }
     }
 
+    /// <summary>
+    /// Represents an entry in the fishing guide.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 0x14)]
     public struct FishGuide2Item
     {
-        //0
+        /// <summary>
+        /// The item ID of the fish.
+        /// </summary>
         [FieldOffset(0x0)]
         public uint FishItem;
 
-        //0x4
+        /// <summary>
+        /// The internal index of the fish in the guide.
+        /// </summary>
         [FieldOffset(0X4)]
         public ushort Index;
 
-        //0x6
+        /// <summary>
+        /// Unknown field.
+        /// </summary>
         [FieldOffset(0x6)]
         public ushort Unknown;
 
-        //0x8
+        /// <summary>
+        /// Unknown field.
+        /// </summary>
         [FieldOffset(0x8)]
         public ushort Unknown2;
 
-        //0xA
+        /// <summary>
+        /// Unknown field.
+        /// </summary>
         [FieldOffset(0xA)]
         public ushort Unknown5;
 
-        //0xE
+        /// <summary>
+        /// Raw byte indicating whether the player has caught this fish (1 if caught, 0 otherwise).
+        /// </summary>
         [FieldOffset(0xE)]
         public byte bHasCaught;
 
+        /// <summary>
+        /// Gets a value indicating whether the player has caught this fish.
+        /// </summary>
         public bool HasCaught => bHasCaught == 1;
 
+        /// <summary>
+        /// Returns a string representation of the fish entry.
+        /// </summary>
+        /// <returns>A string containing the fish name and its caught status.</returns>
         public override string ToString()
         {
             return $"{DataManager.GetItem(FishItem)} : {HasCaught}";

--- a/RemoteAgents/AgentSharlayanCraftworksSupply.cs
+++ b/RemoteAgents/AgentSharlayanCraftworksSupply.cs
@@ -6,10 +6,19 @@ using LlamaLibrary.Utilities;
 
 namespace LlamaLibrary.RemoteAgents;
 
+/// <summary>
+/// Remote agent for the Sharlayan Craftworks item submission interface.
+/// Facilitates the hand-in of crafted items for the Sharlayan Craftworks system.
+/// </summary>
 public class AgentSharlayanCraftworksSupply : AgentInterface<AgentSharlayanCraftworksSupply>, IAgent
 {
+    /// <inheritdoc/>
     public IntPtr RegisteredVtable => AgentSharlayanCraftworksSupplyOffsets.Vtable;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentSharlayanCraftworksSupply"/> class.
+    /// </summary>
+    /// <param name="pointer">The memory address of the agent.</param>
     protected AgentSharlayanCraftworksSupply(IntPtr pointer) : base(pointer)
     {
     }
@@ -22,6 +31,14 @@ public class AgentSharlayanCraftworksSupply : AgentInterface<AgentSharlayanCraft
                                          slot.Slot,
                                          (int)slot.BagId);
     }*/
+
+    /// <summary>
+    /// Hands in the specified <see cref="BagSlot"/> to the Sharlayan Craftworks interface.
+    /// </summary>
+    /// <param name="slot">The inventory slot containing the item to be handed in.</param>
+    /// <remarks>
+    /// The memory offset for the instance pointer differs between the standard and Chinese (TC) clients.
+    /// </remarks>
     public void HandIn(BagSlot slot)
     {
 #if RB_TC


### PR DESCRIPTION
### 📝 Scribe: Add XML documentation for Remote Agents

#### 💡 What:
Added detailed XML documentation to the following classes and structures:
- `AgentFishGuide2` and `FishGuide2Item`
- `AgentBankaCraftworksSupply`
- `AgentSharlayanCraftworksSupply`

#### 🎯 Why:
These classes are part of the core memory-interfacing layer of the library. They were previously undocumented, making it difficult for developers to understand the purpose of specific memory offsets and raw data structures (like the caught status byte in fishing guide items).

#### 🔬 Examples:

**AgentFishGuide2.cs:**
```csharp
/// <summary>
/// Raw byte indicating whether the player has caught this fish (1 if caught, 0 otherwise).
/// </summary>
[FieldOffset(0xE)]
public byte bHasCaught;

/// <summary>
/// Gets a value indicating whether the player has caught this fish.
/// </summary>
public bool HasCaught => bHasCaught == 1;
```

**AgentSharlayanCraftworksSupply.cs:**
```csharp
/// <summary>
/// Hands in the specified <see cref="BagSlot"/> to the Sharlayan Craftworks interface.
/// </summary>
/// <param name="slot">The inventory slot containing the item to be handed in.</param>
/// <remarks>
/// The memory offset for the instance pointer differs between the standard and Chinese (TC) clients.
/// </remarks>
```

---
*PR created automatically by Jules for task [5682411506208009158](https://jules.google.com/task/5682411506208009158) started by @nt153133*