### PR TITLE
📝 Scribe: Add XML documentation for Journal and FateProgress windows

### DIFF
--- a/RemoteWindows/FateProgress.cs
+++ b/RemoteWindows/FateProgress.cs
@@ -1,7 +1,14 @@
 ﻿namespace LlamaLibrary.RemoteWindows
 {
+    /// <summary>
+    /// Interaction interface for the "FateProgress" window.
+    /// Used to view progress for Shared FATEs across different regions.
+    /// </summary>
     public class FateProgress : RemoteWindow<FateProgress>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FateProgress"/> class.
+        /// </summary>
         public FateProgress() : base("FateProgress")
         {
         }

--- a/RemoteWindows/Journal.cs
+++ b/RemoteWindows/Journal.cs
@@ -3,12 +3,23 @@ using ff14bot.Managers;
 
 namespace LlamaLibrary.RemoteWindows;
 
+/// <summary>
+/// Interaction interface for the "Journal" window.
+/// Used to view active, completed, and current quests.
+/// </summary>
 public class Journal : RemoteWindow<Journal>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Journal"/> class.
+    /// </summary>
     public Journal() : base("Journal")
     {
     }
 
+    /// <summary>
+    /// Selects a quest in the journal by its global ID.
+    /// </summary>
+    /// <param name="globalId">The global identifier of the quest to select.</param>
     public void SelectQuest(int globalId)
     {
         var rawId = QuestLogManager.ActiveQuests.FirstOrDefault(i => i.GlobalId == globalId)?.RawId ?? 0;

--- a/RemoteWindows/JournalDetail.cs
+++ b/RemoteWindows/JournalDetail.cs
@@ -3,27 +3,47 @@ using ff14bot.Managers;
 
 namespace LlamaLibrary.RemoteWindows
 {
+    /// <summary>
+    /// Interaction interface for the "JournalDetail" window.
+    /// Displays detailed information for a selected quest or duty.
+    /// </summary>
     public class JournalDetail : RemoteWindow<JournalDetail>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JournalDetail"/> class.
+        /// </summary>
         public JournalDetail() : base("JournalDetail")
         {
         }
 
+        /// <summary>
+        /// Sets the quest to display details for using its global ID.
+        /// </summary>
+        /// <param name="globalId">The global identifier of the quest.</param>
         public void SetQuest(ulong globalId)
         {
             SendAction(3, 3, 0xD, 3, globalId, 3, 2);
         }
 
+        /// <summary>
+        /// Initiates the guildleve specified by its global ID.
+        /// </summary>
+        /// <param name="globalId">The global identifier of the guildleve.</param>
         public void InitiateLeve(ulong globalId)
         {
             SendAction(2, 3, 4, 4, globalId);
         }
 
+        /// <inheritdoc/>
         public override void Close()
         {
             SendAction(1, 3uL, 0xFFFFFFFFuL);
         }
 
+        /// <summary>
+        /// Abandons the active quest specified by its global ID.
+        /// </summary>
+        /// <param name="globalId">The global identifier of the quest to abandon.</param>
         public void AbandonQuest(int globalId)
         {
             var rawId = QuestLogManager.ActiveQuests.FirstOrDefault(i => i.GlobalId == globalId)?.RawId ?? 0;


### PR DESCRIPTION
💡 **What:** Added XML documentation to `Journal`, `JournalDetail`, and `FateProgress` classes and their methods in the `LlamaLibrary.RemoteWindows` namespace.

🎯 **Why:** These core interaction interfaces lacked documentation for their public API surface. Providing clear summaries and parameter descriptions helps developers understand the intent of methods like `InitiateLeve` (guildleves) and correctly use global IDs for quest management.

🔬 **Examples:**
- `Journal.SelectQuest(int globalId)`: "Selects a quest in the journal by its global ID."
- `JournalDetail.InitiateLeve(ulong globalId)`: "Initiates the guildleve specified by its global ID."
- `FateProgress`: "Interaction interface for the 'FateProgress' window. Used to view progress for Shared FATEs across different regions."

---
*PR created automatically by Jules for task [16209754781528875607](https://jules.google.com/task/16209754781528875607) started by @nt153133*