### PR TITLE
Add IsOnFreeTrial() to LocalPlayerExtensions

### DIFF
--- a/Extensions/LocalPlayerExtensions.cs
+++ b/Extensions/LocalPlayerExtensions.cs
@@ -159,6 +159,21 @@ namespace LlamaLibrary.Extensions
         }
 
         /// <summary>
+        /// Condition flag index for the Free Trial state (FFXIVClientStructs Client::Game::Condition, FieldOffset 69).
+        /// </summary>
+        private const byte OnFreeTrialCondition = 69;
+
+        /// <summary>
+        /// Checks whether the current client is running on a Free Trial account.
+        /// </summary>
+        /// <param name="player">The local player instance.</param>
+        /// <returns><see langword="true"/> if the account is a Free Trial account; otherwise <see langword="false"/>.</returns>
+        public static bool IsOnFreeTrial(this LocalPlayer player)
+        {
+            return player.CheckCondition(OnFreeTrialCondition);
+        }
+
+        /// <summary>
         /// Determines if the player has a specific permission, optionally excluding certain conditions.
         /// </summary>
         /// <param name="player">The local player instance.</param>


### PR DESCRIPTION
## What
Adds `LocalPlayer.IsOnFreeTrial()` to `LocalPlayerExtensions`, a reliable local-client check for whether the current account is a Free Trial.

## How
Reads the `OnFreeTrial` condition flag (FFXIVClientStructs `Client::Game::Condition`, `FieldOffset(69)`) through the existing `Offsets.Conditions` base and the `CheckCondition` helper — no new offset/signature to maintain. The index space is already 1:1 with FFXIVClientStructs (e.g. `Offsets.Conditions + 7` == `MeldingMateria` in `AgentMeld`).

```csharp
if (Core.Me.IsOnFreeTrial())
{
    // trial-account path
}
```

This is the reliable check, unlike `BattleCharacter.Icon == PlayerIcon.Trial_Adventurer`, which is the priority-based online-status nameplate icon and gets overridden by other statuses (in duty, AFK, cutscene, combat).

## Verification
`dotnet build -c Debug` succeeds (0 errors). Change is a single 15-line addition; branch is off `origin/main` with LF endings so the diff is exactly the new method.
