### PR TITLE
📝 Scribe: Add XML documentation for PlotSize

### DIFF
--- a/Enums/PlotSize.cs
+++ b/Enums/PlotSize.cs
@@ -1,9 +1,23 @@
 ﻿namespace LlamaLibrary.Enums
 {
+    /// <summary>
+    /// Represents the size categories of housing plots in FFXIV.
+    /// </summary>
     public enum PlotSize : byte
     {
+        /// <summary>
+        /// A small housing plot, typically containing a Cottage.
+        /// </summary>
         Small,
+
+        /// <summary>
+        /// A medium housing plot, typically containing a House.
+        /// </summary>
         Medium,
+
+        /// <summary>
+        /// A large housing plot, typically containing a Mansion.
+        /// </summary>
         Large
     }
 }


### PR DESCRIPTION
Adds XML triple-slash documentation to the PlotSize enum and its members (Small, Medium, Large) inside Enums/PlotSize.cs to map them to FFXIV's building categories (Cottage, House, Mansion).

---
*PR created automatically by Jules for task [5935292532235227050](https://jules.google.com/task/5935292532235227050) started by @nt153133*