### PR TITLE
📝 Scribe: Add XML documentation for AgentWorldTravelSelect and AgentMinionNoteBook

### DIFF
--- a/RemoteAgents/AgentMinionNoteBook.cs
+++ b/RemoteAgents/AgentMinionNoteBook.cs
@@ -9,17 +9,32 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Minion Guide (Notebook) interface.
+    /// Manages the player's minion inventory, providing details on acquired minions and retrieving their names.
+    /// </summary>
     public class AgentMinionNoteBook : AgentInterface<AgentMinionNoteBook>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentMinionNoteBookOffsets.VTable;
 
+        /// <summary>
+        /// Gets the pointer address where the acquired minion list is located.
+        /// </summary>
         public IntPtr MinionListAddress => Pointer + AgentMinionNoteBookOffsets.AgentOffset;
-        
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentMinionNoteBook"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentMinionNoteBook(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Retrieves the array of acquired minions currently stored in the player's notebook.
+        /// </summary>
+        /// <returns>An array of <see cref="MinionStruct"/> representing each acquired minion.</returns>
         public MinionStruct[] GetCurrentMinions()
         {
             var address = Pointer + AgentMinionNoteBookOffsets.AgentOffset;
@@ -28,6 +43,11 @@ namespace LlamaLibrary.RemoteAgents
             return Core.Memory.ReadArray<MinionStruct>(address1, (int)count);
         }
 
+        /// <summary>
+        /// Resolves the in-game name of a minion by its database index.
+        /// </summary>
+        /// <param name="index">The database index of the minion companion.</param>
+        /// <returns>The localized name of the minion, or an empty string if not found.</returns>
         public static string GetMinionName(int index)
         {
             var result = Core.Memory.CallInjectedWraper<IntPtr>(AgentMinionNoteBookOffsets.GetCompanion, index);
@@ -35,12 +55,21 @@ namespace LlamaLibrary.RemoteAgents
         }
     }
 
+    /// <summary>
+    /// Represents a 4-byte memory mapping for an acquired minion within the player's minion guide.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 0x4)]
     public struct MinionStruct
     {
+        /// <summary>
+        /// The database ID of the minion, located at offset 0.
+        /// </summary>
         [FieldOffset(0)]
         public ushort MinionId;
 
+        /// <summary>
+        /// An unknown field at offset 2, reserved for potential internal state or flags.
+        /// </summary>
         [FieldOffset(2)]
         public ushort unknown;
     }

--- a/RemoteAgents/AgentWorldTravelSelect.cs
+++ b/RemoteAgents/AgentWorldTravelSelect.cs
@@ -9,45 +9,114 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the "World Travel" (World Visit System) interface.
+    /// Manages the selection of destination worlds and retrieves available world choices.
+    /// </summary>
+    /// <remarks>
+    /// Under standard client builds, the home world is filtered out of the selectable destination world choices.
+    /// This is controlled via the <c>MaxSkip</c> constant using conditional compilation.
+    /// </remarks>
     public class AgentWorldTravelSelect : AgentInterface<AgentWorldTravelSelect>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentWorldTravelSelectOffsets.VTable;
 
 #if RB_TC
+        /// <summary>
+        /// The offset added to the raw world count to obtain the actual number of destination choices.
+        /// </summary>
         const int MaxCountOffset = -1;
-const int MaxSkip = 0;
+
+        /// <summary>
+        /// The number of elements to skip from the beginning of the world choices list.
+        /// Under <c>RB_TC</c>, this is 0.
+        /// </summary>
+        const int MaxSkip = 0;
 #else
+        /// <summary>
+        /// The offset added to the raw world count to obtain the actual number of destination choices.
+        /// </summary>
         const int MaxCountOffset = -1;
+
+        /// <summary>
+        /// The number of elements to skip from the beginning of the world choices list.
+        /// Under standard clients, this is 1 to skip/filter the player's home world from selectable destinations.
+        /// </summary>
         const int MaxSkip = 1;
 #endif
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentWorldTravelSelect"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentWorldTravelSelect(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Gets the ID of the currently selected world in the world travel interface.
+        /// </summary>
         public ushort CurrentWorld => Core.Memory.NoCacheRead<ushort>(ChoicesPointer + 0x4);
+
+        /// <summary>
+        /// Gets the pointer to the world choices list in game memory.
+        /// </summary>
         public IntPtr ChoicesPointer => Core.Memory.NoCacheRead<IntPtr>(Pointer + AgentWorldTravelSelectOffsets.ChoicesOffset);
 
+        /// <summary>
+        /// Gets the ID of the player's home world.
+        /// </summary>
         public ushort HomeWorld => Core.Memory.NoCacheRead<ushort>(ChoicesPointer);
 
+        /// <summary>
+        /// Gets the total number of worlds available in the travel selection list.
+        /// </summary>
         public int NumberOfWorlds => Core.Memory.NoCacheRead<byte>(Pointer + AgentWorldTravelSelectOffsets.MaxWorldOffset) + MaxCountOffset;
 
+        /// <summary>
+        /// Gets the array of destination world choices available for travel.
+        /// </summary>
+        /// <value>
+        /// An array of <see cref="WorldChoice"/> structures representing the destination worlds.
+        /// </value>
         public WorldChoice[] Choices => Core.Memory.ReadArray<WorldChoice>(ChoicesPointer + 0x8, NumberOfWorlds).Skip(MaxSkip).ToArray();
     }
+
 #if RB_TC
+    /// <summary>
+    /// Represents a world choice option in the world travel interface list for TC builds.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct WorldChoice
     {
+        /// <summary>
+        /// Gets the unique identifier for the world.
+        /// </summary>
         public ushort WorldID;
+
+        /// <summary>
+        /// Gets an unknown/unused field value.
+        /// </summary>
         public ushort Unk;
     }
 #else
+    /// <summary>
+    /// Represents a world choice option in the world travel interface list.
+    /// Maps a 0xC-byte memory entry representing a world choice option to the world details.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 0xC)]
     public struct WorldChoice
     {
+        /// <summary>
+        /// Gets the unique identifier for the world, located at offset 0x4.
+        /// </summary>
         [FieldOffset(0x4)]
         public ushort WorldID;
 
+        /// <summary>
+        /// Gets the corresponding <see cref="World"/> enum value for this world choice.
+        /// </summary>
         public World World => (World)WorldID;
     }
 #endif


### PR DESCRIPTION
### 💡 What
- Added triple-slash XML documentation for `AgentWorldTravelSelect` and `WorldChoice` in `RemoteAgents/AgentWorldTravelSelect.cs`.
- Added triple-slash XML documentation for `AgentMinionNoteBook` and `MinionStruct` in `RemoteAgents/AgentMinionNoteBook.cs`.

### 🎯 Why
- These agents interface directly with game memory but lacked API documentation.
- Documenting how standard client builds filter out the player's home world and how `RB_TC` handles cross-world choices makes the code highly maintainable.
- Explaining the memory mapping structure for minion tracking clarifies domain offsets for future developers.

### 🔬 Examples
```csharp
/// <summary>
/// Remote agent for the "World Travel" (World Visit System) interface.
/// Manages the selection of destination worlds and retrieves available world choices.
/// </summary>
public class AgentWorldTravelSelect : AgentInterface<AgentWorldTravelSelect>, IAgent
```

---
*PR created automatically by Jules for task [1125728175786610027](https://jules.google.com/task/1125728175786610027) started by @nt153133*