### PR TITLE
📝 Scribe: Add XML documentation for LlamaLibrary.Utilities.Inventory

### DIFF
--- a/Utilities/Inventory.cs
+++ b/Utilities/Inventory.cs
@@ -15,13 +15,28 @@ using LlamaLibrary.RemoteWindows;
 
 namespace LlamaLibrary.Utilities
 {
+    /// <summary>
+    /// Provides utility methods and automation tasks for managing player inventory in Final Fantasy XIV.
+    /// This includes automated container opening, unlocking collectible items, batch desynthesis,
+    /// aetherial reduction, and extracting materia from spiritbound gear.
+    /// </summary>
     public static class Inventory
     {
         private static readonly LLogger Log = new("InventoryUtilities", Colors.Green);
 
+        /// <summary>
+        /// Gets a value indicating whether the player's character is currently busy or in a state where
+        /// certain inventory and item operations cannot be performed safely.
+        /// This checks if the player is in an active duty instance, queued for a duty, has a duty pop ready,
+        /// is casting a spell, is mounted, is in combat, has a NPC Talk dialog open, is moving, or is flagged as occupied.
+        /// </summary>
         public static bool IsBusy => DutyManager.InInstance || DutyManager.InQueue || DutyManager.DutyReady || Core.Me.IsCasting || Core.Me.IsMounted || Core.Me.InCombat || Talk.DialogOpen || MovementManager.IsMoving ||
                                      MovementManager.IsOccupied;
 
+        /// <summary>
+        /// Gets the standard character inventory bag identifiers (Bag 1, Bag 2, Bag 3, Bag 4).
+        /// These represent the four main tabs of the player's primary inventory.
+        /// </summary>
         public static readonly InventoryBagId[] InventoryBagIds = new InventoryBagId[4]
         {
             InventoryBagId.Bag1,
@@ -30,6 +45,10 @@ namespace LlamaLibrary.Utilities
             InventoryBagId.Bag4
         };
 
+        /// <summary>
+        /// Gets the identifiers for the 12 primary equipment categories inside the player's Armoury Chest.
+        /// These are used to locate equipment pieces (weapons, armor, accessories) in memory or slots.
+        /// </summary>
         public static readonly InventoryBagId[] ArmoryBagIds = new InventoryBagId[12]
         {
             InventoryBagId.Armory_MainHand,
@@ -46,6 +65,11 @@ namespace LlamaLibrary.Utilities
             InventoryBagId.Armory_Rings
         };
 
+        /// <summary>
+        /// Scans the player's primary inventory for any useable coffer or container items and attempts to open them sequentially.
+        /// Coffers are identified by having an <c>ItemAction</c> ID of <c>388</c>.
+        /// </summary>
+        /// <returns>A <see cref="Task{TResult}"/> indicating whether the scan and opening sequence completed.</returns>
         public static async Task<bool> CofferTask()
         {
             foreach (var bagslot in InventoryManager.FilledSlots.Where(bagslot => bagslot.Item.ItemAction == 388))
@@ -64,6 +88,18 @@ namespace LlamaLibrary.Utilities
             return true;
         }
 
+        /// <summary>
+        /// Scans the player's primary inventory for useable items that unlock collectible game content and uses them sequentially.
+        /// Collectibles are identified by checking the backing action ID:
+        /// <list type="bullet">
+        /// <item><description><c>853</c>: Minions</description></item>
+        /// <item><description><c>25183</c>: Orchestrion Rolls</description></item>
+        /// <item><description><c>3357</c>: Triple Triad Cards</description></item>
+        /// <item><description><c>2136</c>: Master Crafting Books</description></item>
+        /// <item><description><c>4107</c>: Folklore Gathering Tomes</description></item>
+        /// </list>
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static async Task UseUnlockablesAsync()
         {
             var backingActionIds = new HashSet<uint>
@@ -122,6 +158,13 @@ namespace LlamaLibrary.Utilities
             Log.Verbose("Done desynth");
         }
 
+        /// <summary>
+        /// Attempts to desynthesize a collection of items sequentially.
+        /// For each item, it verifies that the item has a valid repair class and that the player's level for that
+        /// class is at least 30. It automatically closes any salvage-related UI windows upon completion.
+        /// </summary>
+        /// <param name="itemsToDesynth">The collection of bag slots representing items to desynthesize.</param>
+        /// <returns>A <see cref="Task{TResult}"/> indicating whether the desynthesis sequence completed successfully (returns <see langword="false"/> if the character is busy or no items are provided).</returns>
         public static async Task<bool> Desynth(IEnumerable<BagSlot> itemsToDesynth)
         {
             await GeneralFunctions.StopBusy(leaveDuty: false);
@@ -173,6 +216,11 @@ namespace LlamaLibrary.Utilities
             return true;
         }
 
+        /// <summary>
+        /// Automatically performs Aetherial Reduction on all reducable items in the character's primary inventory bags.
+        /// Continues sequentially until no more reducable items are found, and automatically dismisses the PurifyResult window.
+        /// </summary>
+        /// <returns>A <see cref="Task{TResult}"/> representing the asynchronous outcome.</returns>
         public static async Task<bool> ReduceAll()
         {
             await GeneralFunctions.StopBusy(false);
@@ -203,6 +251,11 @@ namespace LlamaLibrary.Utilities
             return true;
         }
 
+        /// <summary>
+        /// Extracts materia from all equipped or armory gear that has achieved 100% spiritbond.
+        /// Explicitly excludes Novus Relic Sphere Scrolls (item IDs 7873 to 7882, and 9255) to prevent accidental loss or corruption.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static async Task ExtractFromAllGear()
         {
             await GeneralFunctions.StopBusy(leaveDuty: false);


### PR DESCRIPTION
💡 **What:** Added high-quality, comprehensive XML documentation (triple-slash comments) for the static utility class `LlamaLibrary.Utilities.Inventory`. This covers the class definition, fields/properties (`IsBusy`, `InventoryBagIds`, `ArmoryBagIds`), and core automation tasks (`CofferTask`, `UseUnlockablesAsync`, `Desynth`, `ReduceAll`, `ExtractFromAllGear`).

🎯 **Why:** This static utility class is heavily relied upon for primary inventory actions across various botbases and plugins but completely lacked XML documentation. Tracing and detailing its specific domain behaviors (like looking for Coffer Action ID 388, listing collectible item action categories, or the minimum level requirement of 30 for desynthesis) is crucial for developers working with FFXIV memory mapping and inventory management.

🔬 **Examples:**
```csharp
/// <summary>
/// Scans the player's primary inventory for useable items that unlock collectible game content and uses them sequentially.
/// Collectibles are identified by checking the backing action ID:
/// <list type="bullet">
/// <item><description><c>853</c>: Minions</description></item>
/// <item><description><c>25183</c>: Orchestrion Rolls</description></item>
/// <item><description><c>3357</c>: Triple Triad Cards</description></item>
/// <item><description><c>2136</c>: Master Crafting Books</description></item>
/// <item><description><c>4107</c>: Folklore Gathering Tomes</description></item>
/// </list>
/// </summary>
/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
public static async Task UseUnlockablesAsync()
```

---
*PR created automatically by Jules for task [11171766489519409473](https://jules.google.com/task/11171766489519409473) started by @nt153133*