### PR TITLE
📝 Scribe: Add XML documentation for RemoteAgents

### DIFF
--- a/RemoteAgents/AgentDeepDungeonStatus.cs
+++ b/RemoteAgents/AgentDeepDungeonStatus.cs
@@ -1,21 +1,38 @@
-﻿using System;
+using System;
 using ff14bot.Managers;
 using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents;
 
-public class AgentDeepDungeonStatus: AgentInterface
+/// <summary>
+/// Remote agent for the Deep Dungeon Status interface.
+/// Tracks player progression, stats, and state inside Deep Dungeons such as Palace of the Dead, Heaven-on-High, and Eureka Orthos.
+/// </summary>
+public class AgentDeepDungeonStatus : AgentInterface
 {
+    /// <summary>
+    /// Gets the pointer to the registered virtual function table (VTable) for this agent.
+    /// </summary>
     public IntPtr RegisteredVtable => AgentDeepDungeonStatusOffsets.VTable;
 
     private static AgentInterface? _instance;
 
+    /// <summary>
+    /// Gets the raw identifier of this agent, found dynamically by searching for the agent's VTable in the agent module.
+    /// </summary>
     public static int IdRaw { get; } = AgentModule.FindAgentIdByVtable(AgentDeepDungeonStatusOffsets.VTable);
 
+    /// <summary>
+    /// Gets the singleton instance of the <see cref="AgentDeepDungeonStatus"/> agent.
+    /// Resolves the raw agent pointer dynamically using the agent module and VTable mapping.
+    /// </summary>
     public static AgentInterface Instance => _instance ??= new AgentDeepDungeonStatus(AgentModule.AgentPointers[AgentModule.FindAgentIdByVtable(AgentDeepDungeonStatusOffsets.VTable)]);
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentDeepDungeonStatus"/> class.
+    /// </summary>
+    /// <param name="pointer">The memory address of the agent.</param>
     protected AgentDeepDungeonStatus(IntPtr pointer) : base(pointer)
     {
     }
-
 }

--- a/RemoteAgents/AgentGoldSaucerInfo.cs
+++ b/RemoteAgents/AgentGoldSaucerInfo.cs
@@ -1,15 +1,23 @@
-﻿using System;
+using System;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Gold Saucer Info interface.
+    /// Acts as the primary interface for managing and tracking the overall state of the player's Gold Saucer data, currencies, and stats.
+    /// </summary>
     public class AgentGoldSaucerInfo : AgentInterface<AgentGoldSaucerInfo>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentGoldSaucerInfoOffsets.VTable;
-        
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentGoldSaucerInfo"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentGoldSaucerInfo(IntPtr pointer) : base(pointer)
         {
         }

--- a/RemoteAgents/AgentHousing.cs
+++ b/RemoteAgents/AgentHousing.cs
@@ -1,16 +1,23 @@
-﻿using System;
+using System;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Housing interface.
+    /// Acts as the primary interface for managing and tracking the overall state of the game's internal housing menu.
+    /// </summary>
     public class AgentHousing : AgentInterface<AgentHousing>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentHousingOffsets.VTable;
 
-        
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentHousing"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentHousing(IntPtr pointer) : base(pointer)
         {
         }

--- a/RemoteAgents/AgentHousingSelectBlock.cs
+++ b/RemoteAgents/AgentHousingSelectBlock.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using ff14bot;
 using ff14bot.Managers;
 using LlamaLibrary.Memory.Attributes;
@@ -6,21 +6,38 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the housing ward and plot selection interface.
+    /// Manages the visual block list of housing wards, allowing inspection and updates to ward and plot selection states.
+    /// </summary>
     public class AgentHousingSelectBlock : AgentInterface<AgentHousingSelectBlock>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentHousingSelectBlockOffsets.VTable;
-        
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentHousingSelectBlock"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentHousingSelectBlock(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Gets or sets the selected ward index.
+        /// </summary>
+        /// <value>The zero-based index of the ward (e.g., 0 represents Ward 1, 1 represents Ward 2, etc.).</value>
         public int WardNumber
         {
             get => Core.Memory.Read<int>(Pointer + AgentHousingSelectBlockOffsets.WardNumber);
             set => Core.Memory.Write(Pointer + AgentHousingSelectBlockOffsets.WardNumber, value);
         }
 
+        /// <summary>
+        /// Reads the status or availability of the plots in the currently selected ward from game memory.
+        /// </summary>
+        /// <param name="count">The number of plots to read status/availability data for (typically corresponding to the total number of plots in the residential zone, e.g., 30 or 60).</param>
+        /// <returns>A byte array where each element represents the status or availability code of the respective plot in the ward.</returns>
         public byte[] ReadPlots(int count)
         {
             return Core.Memory.ReadArray<byte>(Pointer + AgentHousingSelectBlockOffsets.PlotOffset, count);

--- a/RemoteAgents/AgentMinionNoteBook.cs
+++ b/RemoteAgents/AgentMinionNoteBook.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using System.Text;
 using ff14bot;
@@ -9,17 +9,32 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Minion Guide (Minion Notebook) interface.
+    /// Manages the player's collection of acquired minions, allowing lookups of unlocked minion IDs and names.
+    /// </summary>
     public class AgentMinionNoteBook : AgentInterface<AgentMinionNoteBook>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentMinionNoteBookOffsets.VTable;
 
+        /// <summary>
+        /// Gets the memory address pointing to the pointer of the acquired minion list array.
+        /// </summary>
         public IntPtr MinionListAddress => Pointer + AgentMinionNoteBookOffsets.AgentOffset;
-        
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentMinionNoteBook"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentMinionNoteBook(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Retrieves the array of acquired minions from game memory.
+        /// </summary>
+        /// <returns>An array of <see cref="MinionStruct"/> structures containing the IDs of all unlocked minions.</returns>
         public MinionStruct[] GetCurrentMinions()
         {
             var address = Pointer + AgentMinionNoteBookOffsets.AgentOffset;
@@ -28,6 +43,11 @@ namespace LlamaLibrary.RemoteAgents
             return Core.Memory.ReadArray<MinionStruct>(address1, (int)count);
         }
 
+        /// <summary>
+        /// Gets the name of the minion at the specified database or row index by calling the game's internal function.
+        /// </summary>
+        /// <param name="index">The index or row ID of the minion companion.</param>
+        /// <returns>The localized name of the minion, or an empty string if not found.</returns>
         public static string GetMinionName(int index)
         {
             var result = Core.Memory.CallInjectedWraper<IntPtr>(AgentMinionNoteBookOffsets.GetCompanion, index);
@@ -35,12 +55,21 @@ namespace LlamaLibrary.RemoteAgents
         }
     }
 
+    /// <summary>
+    /// Represents a 4-byte memory mapping for an acquired minion record.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 0x4)]
     public struct MinionStruct
     {
+        /// <summary>
+        /// The unique identifier of the minion.
+        /// </summary>
         [FieldOffset(0)]
         public ushort MinionId;
 
+        /// <summary>
+        /// Reserved or unknown field at offset 2 of the structure.
+        /// </summary>
         [FieldOffset(2)]
         public ushort unknown;
     }

--- a/RemoteAgents/AgentWorldTravelSelect.cs
+++ b/RemoteAgents/AgentWorldTravelSelect.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using ff14bot;
@@ -9,45 +9,86 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the World Travel Selection interface.
+    /// Manages cross-world travel interactions, tracking home and target world choices.
+    /// </summary>
     public class AgentWorldTravelSelect : AgentInterface<AgentWorldTravelSelect>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentWorldTravelSelectOffsets.VTable;
 
 #if RB_TC
+        /// <summary>The index offset applied to the total world count for the Tencent (China) client.</summary>
         const int MaxCountOffset = -1;
-const int MaxSkip = 0;
+        /// <summary>The number of initial world elements to skip in the choices array for the Tencent (China) client.</summary>
+        const int MaxSkip = 0;
 #else
+        /// <summary>The index offset applied to the total world count.</summary>
         const int MaxCountOffset = -1;
+        /// <summary>The number of initial world elements to skip in the choices array to filter out the home world.</summary>
         const int MaxSkip = 1;
 #endif
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentWorldTravelSelect"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentWorldTravelSelect(IntPtr pointer) : base(pointer)
         {
         }
 
+        /// <summary>
+        /// Gets the ID of the current world the player is on.
+        /// </summary>
         public ushort CurrentWorld => Core.Memory.NoCacheRead<ushort>(ChoicesPointer + 0x4);
+
+        /// <summary>
+        /// Gets the memory address pointing to the list of world choices.
+        /// </summary>
         public IntPtr ChoicesPointer => Core.Memory.NoCacheRead<IntPtr>(Pointer + AgentWorldTravelSelectOffsets.ChoicesOffset);
 
+        /// <summary>
+        /// Gets the ID of the player's home world.
+        /// </summary>
         public ushort HomeWorld => Core.Memory.NoCacheRead<ushort>(ChoicesPointer);
 
+        /// <summary>
+        /// Gets the total number of worlds available for selection.
+        /// </summary>
         public int NumberOfWorlds => Core.Memory.NoCacheRead<byte>(Pointer + AgentWorldTravelSelectOffsets.MaxWorldOffset) + MaxCountOffset;
 
+        /// <summary>
+        /// Gets the list of available world choices for cross-world travel, skipping the home world if applicable based on region.
+        /// </summary>
         public WorldChoice[] Choices => Core.Memory.ReadArray<WorldChoice>(ChoicesPointer + 0x8, NumberOfWorlds).Skip(MaxSkip).ToArray();
     }
+
 #if RB_TC
+    /// <summary>
+    /// Represents a world choice entry in the world travel selection list for the Tencent (China) client.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct WorldChoice
     {
+        /// <summary>The unique world identifier.</summary>
         public ushort WorldID;
+
+        /// <summary>Unknown or reserved field.</summary>
         public ushort Unk;
     }
 #else
+    /// <summary>
+    /// Represents a 12-byte world choice entry in the world travel selection list.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 0xC)]
     public struct WorldChoice
     {
+        /// <summary>The unique world identifier.</summary>
         [FieldOffset(0x4)]
         public ushort WorldID;
 
+        /// <summary>Gets the strongly-typed <see cref="World"/> enum representation of the world identifier.</summary>
         public World World => (World)WorldID;
     }
 #endif


### PR DESCRIPTION
### What
This PR adds comprehensive triple-slash XML documentation to the following undocumented or under-documented classes in the `RemoteAgents` namespace:
- `AgentDeepDungeonStatus`
- `AgentGoldSaucerInfo`
- `AgentHousing`
- `AgentHousingSelectBlock`
- `AgentMinionNoteBook`
- `AgentWorldTravelSelect`

### Why
These FFXIV remote agents interact directly with game memory and UI, making accurate documentation critical for maintainability. The comments explain the underlying memory mappings, indices (such as zero-based vs. one-based indexes), and regional compilation differences.

### Examples
#### AgentHousingSelectBlock
```csharp
/// <summary>
/// Gets or sets the selected ward index.
/// </summary>
/// <value>The zero-based index of the ward (e.g., 0 represents Ward 1, 1 represents Ward 2, etc.).</value>
public int WardNumber
```

#### AgentWorldTravelSelect
```csharp
/// <summary>
/// Gets the list of available world choices for cross-world travel, skipping the home world if applicable based on region.
/// </summary>
public WorldChoice[] Choices
```

---
*PR created automatically by Jules for task [10678382684761110550](https://jules.google.com/task/10678382684761110550) started by @nt153133*