### PR TITLE
📝 Scribe: Add XML documentation for AgentContentsNote and AgentGoldSaucerInfo

### DIFF
--- a/RemoteAgents/AgentContentsNote.cs
+++ b/RemoteAgents/AgentContentsNote.cs
@@ -3,16 +3,30 @@ using ff14bot.Managers;
 
 namespace LlamaLibrary.RemoteAgents
 {
-    /// <summary>Remote agent for the Challenge Log.</summary>
+    /// <summary>
+    /// Remote agent for the Challenge Log interface (ContentsNote).
+    /// Manages the state and provides interaction hooks for the in-game Challenge Log menu.
+    /// </summary>
     public sealed class AgentContentsNote : AgentInterface
     {
+        /// <summary>
+        /// The unique ID identifying the Challenge Log agent in the game's AgentModule.
+        /// </summary>
         public const int AgentId = 136;
 
         private static AgentInterface _instance;
 
+        /// <summary>
+        /// Gets the singleton instance of the <see cref="AgentContentsNote"/> remote agent.
+        /// Lazily initializes using the pointer obtained from the game's <see cref="AgentModule"/>.
+        /// </summary>
         public static AgentInterface Instance =>
             _instance ??= new AgentContentsNote(AgentModule.AgentPointers[AgentId]);
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentContentsNote"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         private AgentContentsNote(IntPtr pointer) : base(pointer)
         {
         }

--- a/RemoteAgents/AgentGoldSaucerInfo.cs
+++ b/RemoteAgents/AgentGoldSaucerInfo.cs
@@ -5,11 +5,19 @@ using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.RemoteAgents
 {
+    /// <summary>
+    /// Remote agent for the Gold Saucer Info interface.
+    /// Manages information and menus related to the Gold Saucer, such as MGP balance, Cactpot tickets, and attractions.
+    /// </summary>
     public class AgentGoldSaucerInfo : AgentInterface<AgentGoldSaucerInfo>, IAgent
     {
+        /// <inheritdoc/>
         public IntPtr RegisteredVtable => AgentGoldSaucerInfoOffsets.VTable;
-        
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentGoldSaucerInfo"/> class.
+        /// </summary>
+        /// <param name="pointer">The memory address of the agent.</param>
         protected AgentGoldSaucerInfo(IntPtr pointer) : base(pointer)
         {
         }


### PR DESCRIPTION
### What
Added comprehensive triple-slash (`///`) XML documentation for `AgentContentsNote` and `AgentGoldSaucerInfo` remote agents.

### Why
To improve the maintainability and type-safety of key UI-remote agents that lacked precise details about what they represent in-game.

### Examples
```csharp
    /// <summary>
    /// Remote agent for the Challenge Log interface (ContentsNote).
    /// Manages the state and provides interaction hooks for the in-game Challenge Log menu.
    /// </summary>
```

---
*PR created automatically by Jules for task [10322268756809881604](https://jules.google.com/task/10322268756809881604) started by @nt153133*