### PR TITLE
Centralize recent native client offsets

### DIFF
--- a/Helpers/MinionHelper.cs
+++ b/Helpers/MinionHelper.cs
@@ -1,12 +1,17 @@
 ﻿using System;
 using ff14bot;
 using LlamaLibrary.Extensions;
+using LlamaLibrary.Memory;
 
 namespace LlamaLibrary.Helpers
 {
     /// <summary>
     /// Provides helpers for summoning and dismissing companion minions via the game action system.
     /// </summary>
+    /// <remarks>
+    /// The active minion ID is read through <see cref="MinionHelperOffsets"/> because GameObject.BaseId
+    /// moved when GimmickId was inserted; resolving the member prevents another stale fixed-layout read.
+    /// </remarks>
     public static class MinionHelper
     {
         /// <summary>
@@ -24,7 +29,7 @@ namespace LlamaLibrary.Helpers
                     return false;
                 }
 
-                return Core.Memory.Read<ushort>(ptr + 0x80) != 0;
+                return Core.Memory.Read<ushort>(ptr + MinionHelperOffsets.CompanionBaseId) != 0;
             }
         }
 
@@ -42,7 +47,7 @@ namespace LlamaLibrary.Helpers
                     return 0;
                 }
 
-                return Core.Memory.Read<ushort>(ptr + 0x80);
+                return Core.Memory.Read<ushort>(ptr + MinionHelperOffsets.CompanionBaseId);
             }
         }
 

--- a/Memory/Offsets.cs
+++ b/Memory/Offsets.cs
@@ -340,10 +340,12 @@ namespace LlamaLibrary.Memory
         internal static IntPtr VTable;
 
         // AgentContentsTimer walks five estate records by deriving the deadline-array base and
-        // then stepping to the status array. Operand metadata marks both structure displacements,
-        // the loop count, and the RIP-relative constant as dynamic. This whole-instruction anchor
-        // resolves the two arrays without keeping client layout in the agent wrapper.
-        [Offset("Search 4C 8D B3 ? ? ? ? 48 2B CE B8 ? ? ? ? F3 0F 7F 45 ? 48 81 C1 ? ? ? ? 41 8B FC 66 0F 6F 05 ? ? ? ? 41 BC ? ? ? ? Add 17 Read32")]
+        // then stepping directly to the status array. Each signature starts at the instruction that
+        // owns the extracted displacement, keeping the Read32 cursor local while the adjacent whole
+        // instructions provide the semantic context needed for a unique match. Ghidra-classified
+        // displacement, immediate, and RIP-relative operands are wildcarded; both patterns matched
+        // exactly once on Global/China 13733124 and TC 13751666 and returned the documented layouts.
+        [Offset("Search 48 81 C1 ? ? ? ? 41 8B FC 66 0F 6F 05 ? ? ? ? 41 BC ? ? ? ? Add 3 Read32")]
         internal static int EstateStatusArray;
 
         [Offset("Search 4C 8D B3 ? ? ? ? 48 2B CE B8 ? ? ? ? F3 0F 7F 45 ? 48 81 C1 ? ? ? ? 41 8B FC 66 0F 6F 05 ? ? ? ? 41 BC ? ? ? ? Add 3 Read32")]
@@ -1203,6 +1205,7 @@ namespace LlamaLibrary.Memory
         // metadata requires the Buddy displacement, record count/stride, call, and branch to be masked.
         // TC emits two alignment NOPs before the loop and retains the older 0x1EA8 layout, so it has a
         // structurally precise override instead of broadening the Global/China anchor around the NOPs.
+        // The regional patterns matched exactly once on Global/China 13733124 and TC 13751666.
         [Offset("Search 48 8D 9E ? ? ? ? BD ? ? ? ? 48 8D 7B ? 90 48 8D 4F ? C7 47 ? ? ? ? ? 4C 89 67 ? 66 44 89 67 ? 44 88 67 ? E8 ? ? ? ? 48 8D BF ? ? ? ? 48 83 ED ? 75 ? Add 3 Read32")]
         [OffsetTC("Search 48 8D 9E ? ? ? ? BD ? ? ? ? 48 8D 7B ? 0F 1F 40 ? 66 0F 1F 84 00 ? ? ? ? 48 8D 4F ? C7 47 ? ? ? ? ? 4C 89 67 ? 66 44 89 67 ? 44 88 67 ? E8 ? ? ? ? 48 8D BF ? ? ? ? 48 83 ED ? 75 ? Add 3 Read32")]
         internal static int Buddy;
@@ -1213,13 +1216,18 @@ namespace LlamaLibrary.Memory
         [Offset("Search 48 89 9B ? ? ? ? 33 C0 44 89 A3 ? ? ? ? 0F 57 C0 44 89 A3 ? ? ? ? 41 8B CC 66 44 89 A3 ? ? ? ? 44 88 A3 ? ? ? ? 44 89 A3 ? ? ? ? Add 3 Read32")]
         internal static int CompanionInfo;
 
-        [Offset("Search 48 89 9B ? ? ? ? 33 C0 44 89 A3 ? ? ? ? 0F 57 C0 44 89 A3 ? ? ? ? 41 8B CC 66 44 89 A3 ? ? ? ? 44 88 A3 ? ? ? ? 44 89 A3 ? ? ? ? Add 28 Read32")]
+        // These field stores occur together during CompanionInfo reset. Each signature begins on the
+        // store that owns the requested displacement, while the following stores distinguish this
+        // constructor block from similar resets elsewhere in UIState. All displacement operands are
+        // wildcarded; the three patterns matched exactly once and Read32 returned the expected absolute
+        // members on Global/China 13733124 and TC 13751666.
+        [Offset("Search 44 88 A3 ? ? ? ? 44 89 A3 ? ? ? ? 66 44 89 A3 ? ? ? ? 44 89 A3 ? ? ? ? 0F 11 83 ? ? ? ? Add 3 Read32")]
         internal static int CompanionSkillPointsAbsolute;
 
-        [Offset("Search 89 83 ? ? ? ? 66 89 83 ? ? ? ? 66 89 83 ? ? ? ? 88 83 ? ? ? ? 88 83 ? ? ? ? Add 10 Read32")]
+        [Offset("Search 66 89 83 ? ? ? ? 88 83 ? ? ? ? 88 83 ? ? ? ? 48 8D 83 ? ? ? ? Add 3 Read32")]
         internal static int CompanionLevelsAbsolute;
 
-        [Offset("Search 48 89 9B ? ? ? ? 33 C0 44 89 A3 ? ? ? ? 0F 57 C0 44 89 A3 ? ? ? ? 41 8B CC 66 44 89 A3 ? ? ? ? 44 88 A3 ? ? ? ? 44 89 A3 ? ? ? ? Add 2F Read32")]
+        [Offset("Search 44 89 A3 ? ? ? ? 66 44 89 A3 ? ? ? ? 44 89 A3 ? ? ? ? 0F 11 83 ? ? ? ? Add 3 Read32")]
         internal static int CompanionActiveCommandAbsolute;
 
         internal static int CompanionSkillPoints => CompanionSkillPointsAbsolute - CompanionInfo;
@@ -1319,14 +1327,16 @@ namespace LlamaLibrary.Memory
     {
         // The expedition agent update validates the selected tab, stores both selected indices, then
         // obtains number-array 113. Register/branch/call operands are masked; the three extracted values
-        // therefore remain tied to one coherent UI update path instead of unrelated immediate matches.
+        // remain tied to that coherent UI update path while each cursor begins on its owning instruction.
+        // Each pattern matched exactly once and its Read8/Read32 result was verified on Global/China
+        // 13733124 and TC 13751666.
         [Offset("Search 41 8B 4F ? 85 C9 78 ? 49 8B 47 ? 3B 48 ? 7C ? 49 8B 47 ? 41 89 77 ? 41 89 5F ? 83 78 ? ? 0F 84 ? ? ? ? 49 8B 4F ? 48 8B 01 FF 50 ? 48 8B C8 BA ? ? ? ? E8 ? ? ? ? Add 3 Read8")]
         internal static int AgentSelectedTab;
 
-        [Offset("Search 41 8B 4F ? 85 C9 78 ? 49 8B 47 ? 3B 48 ? 7C ? 49 8B 47 ? 41 89 77 ? 41 89 5F ? 83 78 ? ? 0F 84 ? ? ? ? 49 8B 4F ? 48 8B 01 FF 50 ? 48 8B C8 BA ? ? ? ? E8 ? ? ? ? Add 1C Read8")]
+        [Offset("Search 41 89 5F ? 83 78 ? ? 0F 84 ? ? ? ? 49 8B 4F ? Add 3 Read8")]
         internal static int AgentSelectedRow;
 
-        [Offset("Search 41 8B 4F ? 85 C9 78 ? 49 8B 47 ? 3B 48 ? 7C ? 49 8B 47 ? 41 89 77 ? 41 89 5F ? 83 78 ? ? 0F 84 ? ? ? ? 49 8B 4F ? 48 8B 01 FF 50 ? 48 8B C8 BA ? ? ? ? E8 ? ? ? ? Add 35 Read32")]
+        [Offset("Search BA ? ? ? ? E8 ? ? ? ? 49 8B 4F ? 48 8B 01 FF 50 ? 48 8B C8 BA ? ? ? ? E8 ? ? ? ? 41 BC ? ? ? ? 48 8D 44 24 ? 41 8B CC Add 1 Read32")]
         internal static int NumberArrayIndex;
     }
 
@@ -1549,7 +1559,9 @@ namespace LlamaLibrary.Memory
     {
         // The serialization path copies GameObject.BaseId immediately before OwnerId and ObjectIndex.
         // Reading the first dword displacement distinguishes BaseId from the GimmickId byte at 0x80,
-        // which was the source of the stale minion ID read after the object layout changed.
+        // which was the source of the stale minion ID read after the object layout changed. All structure
+        // displacements are wildcarded; the pattern matched once and Read32 returned 0x84 on Global/China
+        // 13733124 and TC 13751666.
         [Offset("Search 41 8B 87 ? ? ? ? 89 84 24 ? ? ? ? 41 8B 87 ? ? ? ? 89 84 24 ? ? ? ? 41 0F B6 87 ? ? ? ? Add 3 Read32")]
         internal static int CompanionBaseId;
     }
@@ -1781,20 +1793,22 @@ namespace LlamaLibrary.Memory
     {
         // SearchNodeById reads AtkUldManager.NodeListCount and NodeList before comparing the requested
         // node ID. Displacements and the conditional branch are operand bytes, so the signature keeps
-        // only the stable opcode/register structure and resolves each layout member independently.
+        // only stable opcode/register structure and resolves each member from its owning instruction.
+        // Both patterns matched exactly once and returned 0x42/0x50 on Global/China 13733124 and TC 13751666.
         [Offset("Search 44 0F B7 41 ? 41 0F B7 C3 48 8B 51 ? 66 45 3B D8 73 ? Add 4 Read8")]
         internal static int NodeListCount;
 
-        [Offset("Search 44 0F B7 41 ? 41 0F B7 C3 48 8B 51 ? 66 45 3B D8 73 ? Add C Read8")]
+        [Offset("Search 48 8B 51 ? 66 45 3B D8 73 ? Add 3 Read8")]
         internal static int NodeList;
 
         // This sibling traversal accepts component nodes and distinguishes two component kinds before
         // continuing to the next sibling. That semantic context makes the otherwise-common NodeType and
         // Component loads unique while wildcarding every displacement, immediate, and branch target.
+        // Both patterns matched exactly once and returned 0x40/0xC0 on the same three regional builds.
         [Offset("Search 66 44 39 52 ? 72 ? 48 8B 8A ? ? ? ? 44 0F B6 81 ? ? ? ? 41 80 E0 ? 41 80 F8 ? 75 ? 80 B9 ? ? ? ? ? 75 ? 48 8B 41 ? 80 78 ? ? 74 ? 80 78 ? ? 74 ? 48 8B 52 ? 48 85 D2 75 ? Add 4 Read8")]
         internal static int NodeType;
 
-        [Offset("Search 66 44 39 52 ? 72 ? 48 8B 8A ? ? ? ? 44 0F B6 81 ? ? ? ? 41 80 E0 ? 41 80 F8 ? 75 ? 80 B9 ? ? ? ? ? 75 ? 48 8B 41 ? 80 78 ? ? 74 ? 80 78 ? ? 74 ? 48 8B 52 ? 48 85 D2 75 ? Add A Read32")]
+        [Offset("Search 48 8B 8A ? ? ? ? 44 0F B6 81 ? ? ? ? 41 80 E0 ? 41 80 F8 ? 75 ? 80 B9 ? ? ? ? ? 75 ? 48 8B 41 ? Add 3 Read32")]
         internal static int Component;
 
         // Ghidra identifies the call target, comparison value, branch distance, and bit index as

--- a/Memory/Offsets.cs
+++ b/Memory/Offsets.cs
@@ -338,6 +338,16 @@ namespace LlamaLibrary.Memory
     {
         [Offset("Search 48 8D 05 ? ? ? ? BE ? ? ? ? 48 89 03 48 8D 7B ? Add 3 TraceRelative")]
         internal static IntPtr VTable;
+
+        // AgentContentsTimer walks five estate records by deriving the deadline-array base and
+        // then stepping to the status array. Operand metadata marks both structure displacements,
+        // the loop count, and the RIP-relative constant as dynamic. This whole-instruction anchor
+        // resolves the two arrays without keeping client layout in the agent wrapper.
+        [Offset("Search 4C 8D B3 ? ? ? ? 48 2B CE B8 ? ? ? ? F3 0F 7F 45 ? 48 81 C1 ? ? ? ? 41 8B FC 66 0F 6F 05 ? ? ? ? 41 BC ? ? ? ? Add 17 Read32")]
+        internal static int EstateStatusArray;
+
+        [Offset("Search 4C 8D B3 ? ? ? ? 48 2B CE B8 ? ? ? ? F3 0F 7F 45 ? 48 81 C1 ? ? ? ? 41 8B FC 66 0F 6F 05 ? ? ? ? 41 BC ? ? ? ? Add 3 Read32")]
+        internal static int EstateDeadlineArray;
     }
 
     public static class AgentDawnOffsets
@@ -1186,6 +1196,37 @@ namespace LlamaLibrary.Memory
         internal static int BeastTribeCount;
     }
 
+    public static class BuddySkillOffsets
+    {
+        // UIState constructs nine fixed-size BuddyMember records at the Buddy field. The loop setup,
+        // record initialization, stride, and loop-back form a stable semantic anchor; Ghidra operand
+        // metadata requires the Buddy displacement, record count/stride, call, and branch to be masked.
+        // TC emits two alignment NOPs before the loop and retains the older 0x1EA8 layout, so it has a
+        // structurally precise override instead of broadening the Global/China anchor around the NOPs.
+        [Offset("Search 48 8D 9E ? ? ? ? BD ? ? ? ? 48 8D 7B ? 90 48 8D 4F ? C7 47 ? ? ? ? ? 4C 89 67 ? 66 44 89 67 ? 44 88 67 ? E8 ? ? ? ? 48 8D BF ? ? ? ? 48 83 ED ? 75 ? Add 3 Read32")]
+        [OffsetTC("Search 48 8D 9E ? ? ? ? BD ? ? ? ? 48 8D 7B ? 0F 1F 40 ? 66 0F 1F 84 00 ? ? ? ? 48 8D 4F ? C7 47 ? ? ? ? ? 4C 89 67 ? 66 44 89 67 ? 44 88 67 ? E8 ? ? ? ? 48 8D BF ? ? ? ? 48 83 ED ? 75 ? Add 3 Read32")]
+        internal static int Buddy;
+
+        // Immediately after the member loop, the constructor initializes CompanionInfo. The absolute
+        // member displacements below are converted back to CompanionInfo-relative offsets so callers
+        // retain the native Buddy + CompanionInfo + field addressing model without hard-coded values.
+        [Offset("Search 48 89 9B ? ? ? ? 33 C0 44 89 A3 ? ? ? ? 0F 57 C0 44 89 A3 ? ? ? ? 41 8B CC 66 44 89 A3 ? ? ? ? 44 88 A3 ? ? ? ? 44 89 A3 ? ? ? ? Add 3 Read32")]
+        internal static int CompanionInfo;
+
+        [Offset("Search 48 89 9B ? ? ? ? 33 C0 44 89 A3 ? ? ? ? 0F 57 C0 44 89 A3 ? ? ? ? 41 8B CC 66 44 89 A3 ? ? ? ? 44 88 A3 ? ? ? ? 44 89 A3 ? ? ? ? Add 28 Read32")]
+        internal static int CompanionSkillPointsAbsolute;
+
+        [Offset("Search 89 83 ? ? ? ? 66 89 83 ? ? ? ? 66 89 83 ? ? ? ? 88 83 ? ? ? ? 88 83 ? ? ? ? Add 10 Read32")]
+        internal static int CompanionLevelsAbsolute;
+
+        [Offset("Search 48 89 9B ? ? ? ? 33 C0 44 89 A3 ? ? ? ? 0F 57 C0 44 89 A3 ? ? ? ? 41 8B CC 66 44 89 A3 ? ? ? ? 44 88 A3 ? ? ? ? 44 89 A3 ? ? ? ? Add 2F Read32")]
+        internal static int CompanionActiveCommandAbsolute;
+
+        internal static int CompanionSkillPoints => CompanionSkillPointsAbsolute - CompanionInfo;
+        internal static int CompanionLevels => CompanionLevelsAbsolute - CompanionInfo;
+        internal static int CompanionActiveCommand => CompanionActiveCommandAbsolute - CompanionInfo;
+    }
+
     public static class BlueMageSpellBookOffsets
     {
         [Offset("Search 48 8D 0D ? ? ? ? 8B D3 E8 ? ? ? ? 45 84 F6  Add 3 TraceRelative")]
@@ -1272,6 +1313,21 @@ namespace LlamaLibrary.Memory
 
         [Offset("Search 41 8B 4E ? 8D 93 ? ? ? ? Add 3 Read8")]
         internal static int StructOffset;
+    }
+
+    public static class GcArmyExpeditionOffsets
+    {
+        // The expedition agent update validates the selected tab, stores both selected indices, then
+        // obtains number-array 113. Register/branch/call operands are masked; the three extracted values
+        // therefore remain tied to one coherent UI update path instead of unrelated immediate matches.
+        [Offset("Search 41 8B 4F ? 85 C9 78 ? 49 8B 47 ? 3B 48 ? 7C ? 49 8B 47 ? 41 89 77 ? 41 89 5F ? 83 78 ? ? 0F 84 ? ? ? ? 49 8B 4F ? 48 8B 01 FF 50 ? 48 8B C8 BA ? ? ? ? E8 ? ? ? ? Add 3 Read8")]
+        internal static int AgentSelectedTab;
+
+        [Offset("Search 41 8B 4F ? 85 C9 78 ? 49 8B 47 ? 3B 48 ? 7C ? 49 8B 47 ? 41 89 77 ? 41 89 5F ? 83 78 ? ? 0F 84 ? ? ? ? 49 8B 4F ? 48 8B 01 FF 50 ? 48 8B C8 BA ? ? ? ? E8 ? ? ? ? Add 1C Read8")]
+        internal static int AgentSelectedRow;
+
+        [Offset("Search 41 8B 4F ? 85 C9 78 ? 49 8B 47 ? 3B 48 ? 7C ? 49 8B 47 ? 41 89 77 ? 41 89 5F ? 83 78 ? ? 0F 84 ? ? ? ? 49 8B 4F ? 48 8B 01 FF 50 ? 48 8B C8 BA ? ? ? ? E8 ? ? ? ? Add 35 Read32")]
+        internal static int NumberArrayIndex;
     }
 
     public static class GrandCompanyShopOffsets
@@ -1487,6 +1543,15 @@ namespace LlamaLibrary.Memory
 
         [Offset("Search E8 ? ? ? ? 84 C0 75 ? 8B FB TraceCall")]
         internal static IntPtr HasPermission;
+    }
+
+    public static class MinionHelperOffsets
+    {
+        // The serialization path copies GameObject.BaseId immediately before OwnerId and ObjectIndex.
+        // Reading the first dword displacement distinguishes BaseId from the GimmickId byte at 0x80,
+        // which was the source of the stale minion ID read after the object layout changed.
+        [Offset("Search 41 8B 87 ? ? ? ? 89 84 24 ? ? ? ? 41 8B 87 ? ? ? ? 89 84 24 ? ? ? ? 41 0F B6 87 ? ? ? ? Add 3 Read32")]
+        internal static int CompanionBaseId;
     }
 
     public static class LookingForGroupConditionOffsets
@@ -1714,6 +1779,24 @@ namespace LlamaLibrary.Memory
 
     public static class ShopExchangeCoinOffsets
     {
+        // SearchNodeById reads AtkUldManager.NodeListCount and NodeList before comparing the requested
+        // node ID. Displacements and the conditional branch are operand bytes, so the signature keeps
+        // only the stable opcode/register structure and resolves each layout member independently.
+        [Offset("Search 44 0F B7 41 ? 41 0F B7 C3 48 8B 51 ? 66 45 3B D8 73 ? Add 4 Read8")]
+        internal static int NodeListCount;
+
+        [Offset("Search 44 0F B7 41 ? 41 0F B7 C3 48 8B 51 ? 66 45 3B D8 73 ? Add C Read8")]
+        internal static int NodeList;
+
+        // This sibling traversal accepts component nodes and distinguishes two component kinds before
+        // continuing to the next sibling. That semantic context makes the otherwise-common NodeType and
+        // Component loads unique while wildcarding every displacement, immediate, and branch target.
+        [Offset("Search 66 44 39 52 ? 72 ? 48 8B 8A ? ? ? ? 44 0F B6 81 ? ? ? ? 41 80 E0 ? 41 80 F8 ? 75 ? 80 B9 ? ? ? ? ? 75 ? 48 8B 41 ? 80 78 ? ? 74 ? 80 78 ? ? 74 ? 48 8B 52 ? 48 85 D2 75 ? Add 4 Read8")]
+        internal static int NodeType;
+
+        [Offset("Search 66 44 39 52 ? 72 ? 48 8B 8A ? ? ? ? 44 0F B6 81 ? ? ? ? 41 80 E0 ? 41 80 F8 ? 75 ? 80 B9 ? ? ? ? ? 75 ? 48 8B 41 ? 80 78 ? ? 74 ? 80 78 ? ? 74 ? 48 8B 52 ? 48 85 D2 75 ? Add A Read32")]
+        internal static int Component;
+
         // Ghidra identifies the call target, comparison value, branch distance, and bit index as
         // operand data, so each is wildcarded. The four-instruction semantic anchor matched once in
         // .text on Global 2026.07.16.0001.0000 and TC 2026.07.22.0000.0000; TraceRelative resolves

--- a/RemoteAgents/AgentContentsInfo.cs
+++ b/RemoteAgents/AgentContentsInfo.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using ff14bot;
 using ff14bot.Managers;
 using LlamaLibrary.Memory;
-using LlamaLibrary.Memory.Attributes;
 using LlamaLibrary.Structs.Housing;
 
 namespace LlamaLibrary.RemoteAgents
@@ -11,28 +10,14 @@ namespace LlamaLibrary.RemoteAgents
     /// <summary>
     /// Remote agent for the Contents Info / Timers interface.
     /// </summary>
+    /// <remarks>
+    /// Native estate-array locations are resolved by <see cref="AgentContentsInfoOffsets"/> so the
+    /// wrapper remains region-safe when AgentContentsTimer changes between client builds.
+    /// </remarks>
     public class AgentContentsInfo : AgentInterface<AgentContentsInfo>, IAgent
     {
         private const int EstateSlotCount = 5;
         private const int ScheduledForDemolitionStatus = 4;
-
-        //TODO: Get these hardcoded offsets out of here
-
-        // AgentContentsTimer tail layout. These values are deliberately kept
-        // behind the agent wrapper so consumers never depend on client layout.
-#if RB_TC
-        /// <summary>Byte offset of the five-element estate status array in AgentContentsTimer.</summary>
-        internal const int EstateStatusArray = 0x17DC;
-
-        /// <summary>Byte offset of the five-element Unix deadline array in AgentContentsTimer.</summary>
-        internal const int EstateDeadlineArray = 0x17F0;
-#else
-        /// <summary>Byte offset of the five-element estate status array in AgentContentsTimer.</summary>
-        internal const int EstateStatusArray = 0x17DC;
-
-        /// <summary>Byte offset of the five-element Unix deadline array in AgentContentsTimer.</summary>
-        internal const int EstateDeadlineArray = 0x17F0;
-#endif
 
         // AgentContentsTimer stores FC, private, and shared estates in fixed slots.
         // Slot 1 is not an actionable estate entry and is intentionally omitted.
@@ -65,8 +50,8 @@ namespace LlamaLibrary.RemoteAgents
                 return UnknownSnapshot(now, "The Contents Info agent is unavailable.");
             }
 
-            var statuses = Core.Memory.ReadArray<int>(Pointer + EstateStatusArray, EstateSlotCount);
-            var deadlines = Core.Memory.ReadArray<ulong>(Pointer + EstateDeadlineArray, EstateSlotCount);
+            var statuses = Core.Memory.ReadArray<int>(Pointer + AgentContentsInfoOffsets.EstateStatusArray, EstateSlotCount);
+            var deadlines = Core.Memory.ReadArray<ulong>(Pointer + AgentContentsInfoOffsets.EstateDeadlineArray, EstateSlotCount);
             if (statuses.Length != EstateSlotCount || deadlines.Length != EstateSlotCount)
             {
                 return UnknownSnapshot(now, "The estate timer arrays could not be read completely.");

--- a/RemoteWindows/BuddySkill.cs
+++ b/RemoteWindows/BuddySkill.cs
@@ -1,5 +1,6 @@
 using System;
 using ff14bot;
+using LlamaLibrary.Memory;
 using LlamaLibrary.RemoteWindows.Atk;
 using AtkValueType = LlamaLibrary.RemoteWindows.Atk.ValueType;
 
@@ -12,21 +13,20 @@ namespace LlamaLibrary.RemoteWindows
         Healer = 2,
     }
 
+    /// <summary>Provides access to the companion skill window and its live Buddy state.</summary>
+    /// <remarks>
+    /// Buddy and CompanionInfo members are signature-resolved because this nested UIState layout is
+    /// client-owned and must not be duplicated as fixed offsets in the window wrapper.
+    /// </remarks>
     public class BuddySkill : RemoteWindow<BuddySkill>
     {
-        private const int BuddyOffset = 0x1EF0;
-        private const int CompanionInfoOffset = 0x2370;
-        private const int CompanionSkillPointsOffset = 0x3A;
-        private const int CompanionLevelsOffset = 0x3B;
-        private const int CompanionActiveCommandOffset = 0x3E;
-
         public BuddySkill() : base("BuddySkill")
         {
         }
 
         public int SkillPoints
         {
-            get => ReadCompanionInfoByte(CompanionSkillPointsOffset);
+            get => ReadCompanionInfoByte(BuddySkillOffsets.CompanionSkillPoints);
         }
 
         public int DefenderLevel => GetRoleLevel(BuddySkillRole.Defender);
@@ -35,11 +35,11 @@ namespace LlamaLibrary.RemoteWindows
 
         public int HealerLevel => GetRoleLevel(BuddySkillRole.Healer);
 
-        public int ActiveCommand => ReadCompanionInfoByte(CompanionActiveCommandOffset);
+        public int ActiveCommand => ReadCompanionInfoByte(BuddySkillOffsets.CompanionActiveCommand);
 
         public int GetRoleLevel(BuddySkillRole role)
         {
-            return ReadCompanionInfoByte(CompanionLevelsOffset + (int)role);
+            return ReadCompanionInfoByte(BuddySkillOffsets.CompanionLevels + (int)role);
         }
 
         public int GetNextSkillCost(BuddySkillRole role)
@@ -102,7 +102,7 @@ namespace LlamaLibrary.RemoteWindows
             var uiState = Helpers.UIState.Instance;
             return uiState == IntPtr.Zero
                 ? 0
-                : Core.Memory.Read<byte>(IntPtr.Add(uiState, BuddyOffset + CompanionInfoOffset + offset));
+                : Core.Memory.Read<byte>(IntPtr.Add(uiState, BuddySkillOffsets.Buddy + BuddySkillOffsets.CompanionInfo + offset));
         }
     }
 }

--- a/RemoteWindows/GcArmyExpedition.cs
+++ b/RemoteWindows/GcArmyExpedition.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using ff14bot;
 using LlamaLibrary.ClientDataHelpers;
+using LlamaLibrary.Memory;
 using LlamaLibrary.RemoteWindows.Atk;
 using AtkValueType = LlamaLibrary.RemoteWindows.Atk.ValueType;
 
@@ -11,6 +12,10 @@ namespace LlamaLibrary.RemoteWindows
     /// <summary>
     /// Read-only access to the autonomous adventurer squadron mission window.
     /// </summary>
+    /// <remarks>
+    /// Agent selection fields and the addon number-array index are resolved from the expedition update
+    /// path so region or patch-specific client layout never leaks into this window abstraction.
+    /// </remarks>
     public class GcArmyExpedition : RemoteWindow<GcArmyExpedition>
     {
         private const int MissionStart = 9;
@@ -20,14 +25,10 @@ namespace LlamaLibrary.RemoteWindows
         {
         }
 
-        private const int NumberArrayIndex = 113;
-        private const int AgentSelectedTabOffset = 0x40;
-        private const int AgentSelectedRowOffset = 0x44;
-
-        public int SelectedCategory => ReadAgentInt(AgentSelectedTabOffset, ReadInt(0));
+        public int SelectedCategory => ReadAgentInt(GcArmyExpeditionOffsets.AgentSelectedTab, ReadInt(0));
         public GcArmyMissionCategory SelectedCategoryType => (GcArmyMissionCategory)SelectedCategory;
         public int CategoryCount => ReadInt(1);
-        public int SelectedMissionIndex => ReadAgentInt(AgentSelectedRowOffset, -1);
+        public int SelectedMissionIndex => ReadAgentInt(GcArmyExpeditionOffsets.AgentSelectedRow, -1);
         public bool CanDeploy => ReadBool(8);
 
         /// <summary>Gets the selected mission's game-data row ID.</summary>
@@ -63,7 +64,7 @@ namespace LlamaLibrary.RemoteWindows
         {
             get
             {
-                var numberArray = AtkArrayDataHolder.NumberArray(NumberArrayIndex);
+                var numberArray = AtkArrayDataHolder.NumberArray(GcArmyExpeditionOffsets.NumberArrayIndex);
                 if (numberArray == IntPtr.Zero)
                 {
                     return Array.Empty<int>();

--- a/RemoteWindows/ShopExchangeCoin.cs
+++ b/RemoteWindows/ShopExchangeCoin.cs
@@ -8,13 +8,13 @@ namespace LlamaLibrary.RemoteWindows
     /// <summary>
     /// Interaction interface for exchanging gil for MGP.
     /// </summary>
+    /// <remarks>
+    /// Atk node-layout members are signature-resolved because they belong to native UI structures and
+    /// must track all supported clients instead of being frozen in this window implementation.
+    /// </remarks>
     public class ShopExchangeCoin : RemoteWindow<ShopExchangeCoin>
     {
         private const int UldManagerOffset = 0x28;
-        private const int NodeListCountOffset = 0x42;
-        private const int NodeListOffset = 0x50;
-        private const int NodeTypeOffset = 0x40;
-        private const int ComponentOffset = 0xC0;
         private const ushort ComponentNodeTypeStart = 1000;
         private const int NumericInputComponentType = 8;
 
@@ -88,8 +88,8 @@ namespace LlamaLibrary.RemoteWindows
             }
 
             var uldManager = window.Pointer + UldManagerOffset;
-            var nodeCount = Core.Memory.Read<ushort>(uldManager + NodeListCountOffset);
-            var nodeList = Core.Memory.Read<IntPtr>(uldManager + NodeListOffset);
+            var nodeCount = Core.Memory.Read<ushort>(uldManager + ShopExchangeCoinOffsets.NodeListCount);
+            var nodeList = Core.Memory.Read<IntPtr>(uldManager + ShopExchangeCoinOffsets.NodeList);
             if (nodeList == IntPtr.Zero)
             {
                 return IntPtr.Zero;
@@ -99,12 +99,12 @@ namespace LlamaLibrary.RemoteWindows
             {
                 var node = Core.Memory.Read<IntPtr>(nodeList + (index * IntPtr.Size));
                 if (node == IntPtr.Zero ||
-                    Core.Memory.Read<ushort>(node + NodeTypeOffset) < ComponentNodeTypeStart)
+                    Core.Memory.Read<ushort>(node + ShopExchangeCoinOffsets.NodeType) < ComponentNodeTypeStart)
                 {
                     continue;
                 }
 
-                var component = Core.Memory.Read<IntPtr>(node + ComponentOffset);
+                var component = Core.Memory.Read<IntPtr>(node + ShopExchangeCoinOffsets.Component);
                 if (component == IntPtr.Zero)
                 {
                     continue;


### PR DESCRIPTION
## Summary
- move ShopExchangeCoin node layout, GcArmyExpedition state, Buddy/CompanionInfo fields, and AgentContentsInfo estate arrays into `Memory/Offsets.cs`
- replace the stale minion `GameObject.BaseId` read with a semantic signature that resolves the post-GimmickId layout
- use operand-masked, whole-instruction anchors and preserve the structurally different TC Buddy constructor with an `OffsetTC` override
- document the anchor rationale, extraction semantics, and compatibility constraints next to the affected behavior

## Verification
- `dotnet build LlamaLibrary.sln --no-restore`
- `dotnet build LlamaLibrary.csproj --no-restore -c China`
- `dotnet build LlamaLibrary.csproj --no-restore -c Release2 -p:DefineConstants=TRACE%3BRB_TC`
- regional offset verifier: Global 445/445, China 445/445, TC 445/445 ([run](https://github.com/DomesticWarlord/__LlamaLibrary/actions/runs/30919242891))
- local instruction-metadata scan confirmed every new pattern has exactly one `.text` match and resolves the expected field/value on the available client binaries

All changed files were reviewed against the durable change-documentation policy.