### PR TITLE
fix(retainers): read Claims once per session as the contract promises

### DIFF
--- a/Retainers/Coordination/IRetainerSessionParticipant.cs
+++ b/Retainers/Coordination/IRetainerSessionParticipant.cs
@@ -79,6 +79,10 @@ namespace LlamaLibrary.Retainers.Coordination
         /// inventory, not the retainer's bag, so collecting first lets fresh loot that stacks with the
         /// retainer's existing stock be entrusted on the same visit.
         /// </para>
+        /// <para>
+        /// Ties resolve by registration order, which follows plugin load order and is not deterministic
+        /// across products. Coordinate distinct priorities instead of relying on it.
+        /// </para>
         /// </remarks>
         int Priority { get; }
 
@@ -168,13 +172,21 @@ namespace LlamaLibrary.Retainers.Coordination
         Task OnRetainer(RetainerSessionContext context, RetainerInfo retainer);
 
         /// <summary>
-        /// Called once after the retainer list is closed, whether or not the session completed cleanly.
+        /// Called once at the end of the trip, after the broker has attempted to close the retainer list.
         /// </summary>
         /// <param name="context">The session context, carrying the final pass count.</param>
         /// <returns>A task that completes when this participant has finished tidying up.</returns>
         /// <remarks>
+        /// <para>
         /// The place for post-session work that does not need a retainer selected — combining stacks,
         /// clearing caches, stamping a last-run time. The player may no longer be at the bell.
+        /// </para>
+        /// <para>
+        /// Only a session that made a trip gets this call. A session that ended before the retainer list
+        /// was opened does not, and neither does one the bot stopped:
+        /// <see cref="Buddy.Coroutines.CoroutineStoppedException"/> unwinds the whole trip, this callback
+        /// included. Keep anything correctness depends on out of here.
+        /// </para>
         /// </remarks>
         Task OnSessionEnded(RetainerSessionContext context);
     }

--- a/Retainers/Coordination/RetainerSessionBroker.cs
+++ b/Retainers/Coordination/RetainerSessionBroker.cs
@@ -329,7 +329,7 @@ namespace LlamaLibrary.Retainers.Coordination
             // Claims are read here, once, after the trip is committed and before any callback runs. Never at
             // registration time, so a participant whose claims depend on configuration is read as configured
             // now rather than as configured when its plugin was enabled.
-            var context = new RetainerSessionContext(snapshot, ResolveClaims(Active(participants)), requestedBy);
+            var context = new RetainerSessionContext(snapshot, ResolveClaims(Active(participants), failures), requestedBy);
             Log.Information($"Session requested by {string.Join(", ", requestedBy)}. Claims: {context.DescribeClaims()}.");
 
             await GeneralFunctions.StopBusy(dismount: false);
@@ -511,33 +511,42 @@ namespace LlamaLibrary.Retainers.Coordination
         /// Assigns each capability to the lowest-priority participant that claims it.
         /// </summary>
         /// <param name="participants">Participants already ordered by priority, ascending.</param>
+        /// <param name="failures">Failure tally to record participants whose <see cref="IRetainerSessionParticipant.Claims"/> threw.</param>
         /// <returns>A map of capability to owning participant id, omitting capabilities nobody claimed.</returns>
-        private static Dictionary<RetainerCapability, string> ResolveClaims(List<IRetainerSessionParticipant> participants)
+        private static Dictionary<RetainerCapability, string> ResolveClaims(List<IRetainerSessionParticipant> participants, Dictionary<string, int> failures)
         {
+            // Read each participant's Claims exactly once, as the interface contract promises. Reading it
+            // per capability would invoke the getter five times, and a settings change between reads could
+            // tear the claim set: owning Ventures from the old configuration but not Gil from the new.
+            var declared = new List<(string Id, RetainerCapability Claims)>();
+
+            foreach (var participant in participants)
+            {
+                try
+                {
+                    declared.Add((participant.Id, participant.Claims));
+                    RecordSuccess(participant.Id);
+                }
+                catch (CoroutineStoppedException)
+                {
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    RecordFailure(participant.Id, "Claims", failures);
+                    Log.Error($"[{participant.Id}] Claims threw, treating as None: {e}");
+                }
+            }
+
             var owners = new Dictionary<RetainerCapability, string>();
 
             foreach (var capability in SingleCapabilities)
             {
-                foreach (var participant in participants)
+                foreach (var (id, claims) in declared)
                 {
-                    RetainerCapability claims;
-                    try
-                    {
-                        claims = participant.Claims;
-                    }
-                    catch (CoroutineStoppedException)
-                    {
-                        throw;
-                    }
-                    catch (Exception e)
-                    {
-                        Log.Error($"[{participant.Id}] Claims threw, treating as None: {e}");
-                        continue;
-                    }
-
                     if ((claims & capability) == capability)
                     {
-                        owners[capability] = participant.Id;
+                        owners[capability] = id;
                         break;
                     }
                 }


### PR DESCRIPTION
ResolveClaims read each participant's Claims getter once per capability, up to five times per session. The interface documents a single read per session, and a configuration change between reads could tear the claim set: owning Ventures from the old config but not Gil from the new. Claims is now read exactly once per participant, a throwing getter counts toward the consecutive-failure streak (stage "Claims") like every other callback, and a clean read clears the streak.

Also tightens two interface docs ahead of the freeze: OnSessionEnded now states it only runs for sessions that made a trip and not when the bot stops mid-session, and Priority documents that ties resolve by registration order, which follows plugin load order, so products should coordinate distinct priorities rather than rely on it.

Rationale:
The interface freezes on publish, so its doc statements are contract. The Claims multi-read was the one place the implementation disagreed with its own documented contract, and the doc gaps were the two places a participant author could reasonably assume behavior the broker does not provide.

Tests:
dotnet build -c Release: both TFMs (net8.0-windows, net10.0-windows), 0 errors. The 14 warnings are pre-existing in unrelated files.