### PR TITLE
feat(retainers): shared retainer session broker

### DIFF
--- a/Retainers/Coordination/IRetainerSessionParticipant.cs
+++ b/Retainers/Coordination/IRetainerSessionParticipant.cs
@@ -1,0 +1,181 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LlamaLibrary.Structs;
+
+namespace LlamaLibrary.Retainers.Coordination
+{
+    /// <summary>
+    /// A consumer of a shared summoning-bell trip. Implement this to have work performed at the retainer
+    /// window without owning the trip to the bell.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Register with <see cref="RetainerSessionBroker.Register"/>. The broker makes at most one trip at a
+    /// time, opens the retainer list once, and calls <see cref="OnRetainer"/> for every participant on every
+    /// retainer it visits.
+    /// </para>
+    /// <para>
+    /// The important consequence: <see cref="WantsSession"/> returning <see langword="false"/> does
+    /// <b>not</b> exclude you from the trip. If any other participant wants a session you are still called
+    /// for every retainer, so you never need a trigger whose only purpose is to justify a trip you would
+    /// have wanted anyway.
+    /// </para>
+    /// <para>
+    /// Every callback is invoked inside a try/catch. Throwing fails only your participant for that stage —
+    /// it is logged and recorded on <see cref="RetainerSessionResult.ParticipantFailures"/>, and the other
+    /// participants continue unaffected. The one exception deliberately not caught is
+    /// <see cref="Buddy.Coroutines.CoroutineStoppedException"/>: it means the bot is stopping, so it
+    /// propagates and unwinds the trip rather than letting it keep driving retainer windows. Do not swallow
+    /// it in your own callbacks either. Repeated failures retire a participant for the session — see
+    /// <see cref="RetainerSessionBroker.MaxConsecutiveFailures"/>.
+    /// </para>
+    /// <para>
+    /// <b>If you move items, you must say so.</b> Call
+    /// <see cref="RetainerSessionContext.NotifyItemsMoved"/> whenever a callback moves an item between the
+    /// player, a retainer or the saddlebag — entrusting, retrieving, collecting venture rewards, anything
+    /// that changes where a stack lives. Other participants plan against inventory contents, and a plan
+    /// built before your move is wrong afterwards. Skipping this call does not fail loudly; it silently
+    /// corrupts someone else's posting plan, which is the single easiest way to break a shared trip.
+    /// </para>
+    /// <para>
+    /// Register with <see cref="RetainerSessionBroker.Register"/> on enable and
+    /// <see cref="RetainerSessionBroker.Unregister"/> on disable. Registration is an upsert keyed on
+    /// <see cref="Id"/>, so a plugin reload that re-registers replaces the old instance rather than adding a
+    /// second one.
+    /// </para>
+    /// <para>
+    /// <b>This interface is frozen once published.</b> A consumer that compiles against one LlamaLibrary
+    /// version and binds to another at runtime fails to load outright — not gracefully — if the interface
+    /// changed shape, taking its whole botbase with it. New capabilities are therefore added to
+    /// <see cref="RetainerSessionContext"/> or to a separate interface, never as new members here. Document
+    /// a minimum LlamaLibrary version for any build that implements this.
+    /// </para>
+    /// </remarks>
+    public interface IRetainerSessionParticipant
+    {
+        /// <summary>
+        /// Gets a stable identifier for this participant, unique across all registrations.
+        /// </summary>
+        /// <value>Used for claim ownership, logging and <see cref="RetainerSessionBroker.Unregister"/>. Use the product name.</value>
+        string Id { get; }
+
+        /// <summary>
+        /// Gets this participant's ordering weight. Lower runs first.
+        /// </summary>
+        /// <value>
+        /// Serves two purposes at once, and they agree: it is the order <see cref="OnRetainer"/> is called in
+        /// while a retainer is selected, and it is how overlapping <see cref="Claims"/> are resolved — the
+        /// lowest-priority participant claiming a capability owns it.
+        /// </value>
+        /// <remarks>
+        /// <para>
+        /// Retainer housekeeping must run before market operations, because entrusting or retrieving items
+        /// invalidates any posting plan built earlier in the session. Participants that move items should
+        /// therefore sit at a lower priority than participants that post them.
+        /// </para>
+        /// <para>
+        /// The canonical order of work within one retainer is: <b>ventures, entrust, gil, pricing, retrieve,
+        /// post</b>. Ventures precede entrust deliberately — venture rewards land in the <i>player's</i>
+        /// inventory, not the retainer's bag, so collecting first lets fresh loot that stacks with the
+        /// retainer's existing stock be entrusted on the same visit.
+        /// </para>
+        /// </remarks>
+        int Priority { get; }
+
+        /// <summary>
+        /// Gets the work this participant is willing and able to perform this session.
+        /// </summary>
+        /// <value>
+        /// May vary with settings: return <see cref="RetainerCapability.None"/> for work you currently
+        /// cannot do and the claim passes to the next participant that wants it.
+        /// </value>
+        /// <remarks>
+        /// <b>Read once per session</b>, after a participant has committed to a trip and before any other
+        /// callback runs — never cached at registration time. That is part of this contract, not an
+        /// implementation detail: it is what lets a participant key its claims on configuration that the
+        /// user can change between sessions without re-registering.
+        /// </remarks>
+        RetainerCapability Claims { get; }
+
+        /// <summary>
+        /// Asks whether this participant has enough work to justify a trip to the summoning bell.
+        /// </summary>
+        /// <param name="snapshot">Active retainers as read at the start of this evaluation.</param>
+        /// <returns>
+        /// <see langword="true"/> if a trip is worth making. Returning <see langword="false"/> does not
+        /// exclude this participant from a trip another participant triggers.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// Called on every broker poll, so keep it cheap. Settings and plain memory reads — a currency count,
+        /// an inventory slot tally — are fine; window interaction, navigation and network traffic are not.
+        /// </para>
+        /// <para>
+        /// Prefer <paramref name="snapshot"/> over a separately persisted copy of retainer state. The
+        /// snapshot is the one view all participants share; a private copy can be invalidated by another
+        /// participant's actions without you ever observing the change, which is the precise failure this
+        /// broker exists to remove.
+        /// </para>
+        /// <para>
+        /// This snapshot is the cheap read. Once a trip is committed the broker forces a fresh one from the
+        /// server, and that — not this — is what <see cref="RetainerSessionContext.Snapshot"/> carries.
+        /// </para>
+        /// </remarks>
+        Task<bool> WantsSession(RetainerInfo[] snapshot);
+
+        /// <summary>
+        /// Names the retainers this participant needs selected.
+        /// </summary>
+        /// <param name="snapshot">Active retainers as read at the start of the session.</param>
+        /// <returns>Content ids (<see cref="RetainerInfo.Unique"/>) of retainers of interest; may be empty.</returns>
+        /// <remarks>
+        /// The broker visits the union across all participants, in retainer-list order, so expect
+        /// <see cref="OnRetainer"/> for retainers you did not ask for. Return early and cheaply in that case.
+        /// </remarks>
+        IEnumerable<ulong> RetainersOfInterest(RetainerInfo[] snapshot);
+
+        /// <summary>
+        /// Called once per pass, after the retainer list is open and before the first retainer is selected.
+        /// </summary>
+        /// <param name="context">The session context.</param>
+        /// <returns>A task that completes when this participant is ready for the pass.</returns>
+        /// <remarks>
+        /// The place to build any plan that spans retainers. Rebuild it on every pass rather than only the
+        /// first: <see cref="RetainerSessionContext.Pass"/> tells you which pass you are in, and earlier
+        /// passes may have moved items between retainers.
+        /// </remarks>
+        Task OnSessionStarting(RetainerSessionContext context);
+
+        /// <summary>
+        /// Called with <paramref name="retainer"/> already selected and its menu open.
+        /// </summary>
+        /// <param name="context">The session context.</param>
+        /// <param name="retainer">The selected retainer, taken from the session snapshot.</param>
+        /// <returns>A task that completes when this participant is done with this retainer.</returns>
+        /// <remarks>
+        /// <para>
+        /// Check <see cref="RetainerSessionContext.IsOwnedBy"/> before performing any claimed work. It is the
+        /// only gate you need: it covers both another participant owning the capability and the capability
+        /// being closed for the current pass. Housekeeping runs on the first pass only, and
+        /// <see cref="RetainerSessionContext.IsOwnedBy"/> enforces that for you.
+        /// </para>
+        /// <para>
+        /// Do not deselect the retainer or close the list — the broker owns the window. Call
+        /// <see cref="RetainerSessionContext.NotifyItemsMoved"/> if you move items, and
+        /// <see cref="RetainerSessionContext.RequestAdditionalPass"/> if that means another lap is needed.
+        /// </para>
+        /// </remarks>
+        Task OnRetainer(RetainerSessionContext context, RetainerInfo retainer);
+
+        /// <summary>
+        /// Called once after the retainer list is closed, whether or not the session completed cleanly.
+        /// </summary>
+        /// <param name="context">The session context, carrying the final pass count.</param>
+        /// <returns>A task that completes when this participant has finished tidying up.</returns>
+        /// <remarks>
+        /// The place for post-session work that does not need a retainer selected — combining stacks,
+        /// clearing caches, stamping a last-run time. The player may no longer be at the bell.
+        /// </remarks>
+        Task OnSessionEnded(RetainerSessionContext context);
+    }
+}

--- a/Retainers/Coordination/IRetainerSessionParticipant.cs
+++ b/Retainers/Coordination/IRetainerSessionParticipant.cs
@@ -79,6 +79,10 @@ namespace LlamaLibrary.Retainers.Coordination
         /// inventory, not the retainer's bag, so collecting first lets fresh loot that stacks with the
         /// retainer's existing stock be entrusted on the same visit.
         /// </para>
+        /// <para>
+        /// Ties resolve by registration order, which follows plugin load order and is not deterministic
+        /// across products. Coordinate distinct priorities instead of relying on it.
+        /// </para>
         /// </remarks>
         int Priority { get; }
 
@@ -168,13 +172,21 @@ namespace LlamaLibrary.Retainers.Coordination
         Task OnRetainer(RetainerSessionContext context, RetainerInfo retainer);
 
         /// <summary>
-        /// Called once after the retainer list is closed, whether or not the session completed cleanly.
+        /// Called once at the end of the trip, after the broker has attempted to close the retainer list.
         /// </summary>
         /// <param name="context">The session context, carrying the final pass count.</param>
         /// <returns>A task that completes when this participant has finished tidying up.</returns>
         /// <remarks>
+        /// <para>
         /// The place for post-session work that does not need a retainer selected — combining stacks,
         /// clearing caches, stamping a last-run time. The player may no longer be at the bell.
+        /// </para>
+        /// <para>
+        /// Only a session that made a trip gets this call. A session that ended before the retainer list
+        /// was opened does not, and neither does one the bot stopped:
+        /// <see cref="Buddy.Coroutines.CoroutineStoppedException"/> unwinds the whole trip, this callback
+        /// included. Keep anything correctness depends on out of here.
+        /// </para>
         /// </remarks>
         Task OnSessionEnded(RetainerSessionContext context);
     }

--- a/Retainers/Coordination/RetainerCapability.cs
+++ b/Retainers/Coordination/RetainerCapability.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace LlamaLibrary.Retainers.Coordination
+{
+    /// <summary>
+    /// The units of retainer work that a <see cref="IRetainerSessionParticipant"/> can claim ownership of
+    /// for the duration of a session.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Claims exist so that two products which can both perform the same action — collecting gil, entrusting
+    /// duplicates, reassigning a venture — agree on exactly one owner per session instead of doing the work
+    /// twice or racing each other.
+    /// </para>
+    /// <para>
+    /// A participant should declare <b>everything it is willing and able to do</b>, not just the work it
+    /// prefers to own. <see cref="RetainerSessionBroker"/> resolves overlapping claims by
+    /// <see cref="IRetainerSessionParticipant.Priority"/> (lowest wins), so declaring a capability you would
+    /// only perform as a fallback is correct: you simply lose the claim whenever a higher-priority
+    /// participant is present, and win it when it is not.
+    /// </para>
+    /// <para>
+    /// Claim only what your configuration will actually service. Claims are read once per session, so key
+    /// them on config rather than on installation: claim <see cref="Entrust"/> when at least one enabled
+    /// entry is set to entrust, not merely because you implement entrusting. A capability that is claimed
+    /// but never acted on is worse than an unclaimed one — it silences the participant that would have done
+    /// the work, and the user sees a feature go quiet with nothing in the log to explain it.
+    /// </para>
+    /// <para>
+    /// Where two products can both service a capability, the winner's per-retainer configuration is
+    /// authoritative for it, including a setting that means "leave this retainer alone". Both products
+    /// should document which of their switches stop applying when the other is installed, so a user running
+    /// both can predict what each one does.
+    /// </para>
+    /// </remarks>
+    [Flags]
+    public enum RetainerCapability
+    {
+        /// <summary>No claim. A participant that only observes, or one whose feature tier is currently locked.</summary>
+        None = 0,
+
+        /// <summary>Collecting a completed venture and assigning the next one.</summary>
+        Ventures = 1 << 0,
+
+        /// <summary>Moving the retainer's gil into the player's inventory.</summary>
+        Gil = 1 << 1,
+
+        /// <summary>Entrusting duplicate stacks from the player's inventory to the retainer.</summary>
+        Entrust = 1 << 2,
+
+        /// <summary>Adjusting the prices of the retainer's existing market board listings.</summary>
+        Pricing = 1 << 3,
+
+        /// <summary>Posting new items to the market board, and retrieving items in order to post them.</summary>
+        Posting = 1 << 4,
+
+        /// <summary>
+        /// The retainer-housekeeping group: <see cref="Ventures"/>, <see cref="Gil"/> and <see cref="Entrust"/>.
+        /// </summary>
+        /// <remarks>
+        /// These run on the <b>first pass only</b>, enforced by
+        /// <see cref="RetainerSessionContext.IsOwnedBy"/>. Later passes exist to move items out of retainer
+        /// bags and post them; re-running housekeeping would entrust those same stacks straight back in.
+        /// </remarks>
+        Housekeeping = Ventures | Gil | Entrust,
+
+        /// <summary>
+        /// The market-operations group: <see cref="Pricing"/> and <see cref="Posting"/>.
+        /// </summary>
+        Market = Pricing | Posting,
+    }
+}

--- a/Retainers/Coordination/RetainerSessionBroker.cs
+++ b/Retainers/Coordination/RetainerSessionBroker.cs
@@ -10,6 +10,7 @@ using ff14bot.Objects;
 using ff14bot.RemoteWindows;
 using LlamaLibrary.Helpers;
 using LlamaLibrary.Helpers.NPC;
+using LlamaLibrary.Helpers.Ping;
 using LlamaLibrary.Logging;
 using LlamaLibrary.Structs;
 using RetainerList = LlamaLibrary.RemoteWindows.RetainerList;
@@ -332,6 +333,14 @@ namespace LlamaLibrary.Retainers.Coordination
             Log.Information($"Session requested by {string.Join(", ", requestedBy)}. Claims: {context.DescribeClaims()}.");
 
             await GeneralFunctions.StopBusy(dismount: false);
+
+            // Participants pace their window interaction against PingChecker.CurrentPing, which is 0 until
+            // something measures it. Left unmeasured, every latency sleep in a participant collapses to
+            // nothing and it races the client - writing to an agent before the window it belongs to has
+            // settled. Measuring here makes it a property of the trip rather than something each
+            // participant has to remember.
+            await PingChecker.UpdatePing();
+            Log.Debug($"Ping measured at {PingChecker.CurrentPing}ms.");
 
             if (!await LeaveBarracks())
             {

--- a/Retainers/Coordination/RetainerSessionBroker.cs
+++ b/Retainers/Coordination/RetainerSessionBroker.cs
@@ -1,0 +1,678 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Media;
+using Buddy.Coroutines;
+using ff14bot.Behavior;
+using ff14bot.Managers;
+using ff14bot.Objects;
+using ff14bot.RemoteWindows;
+using LlamaLibrary.Helpers;
+using LlamaLibrary.Helpers.NPC;
+using LlamaLibrary.Logging;
+using LlamaLibrary.Structs;
+using RetainerList = LlamaLibrary.RemoteWindows.RetainerList;
+
+namespace LlamaLibrary.Retainers.Coordination
+{
+    /// <summary>
+    /// Owns the trip to the summoning bell so that every product needing retainer work shares one visit
+    /// instead of racing for it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Products register an <see cref="IRetainerSessionParticipant"/> and stop navigating to the bell
+    /// themselves. Any scheduler may call <see cref="RunIfWanted"/>; a re-entrancy guard means the first
+    /// caller in makes the trip and the rest are told a session is already running. Neither product needs
+    /// to give up its own hook or task loop, and neither takes a dependency on the other.
+    /// </para>
+    /// <para>
+    /// The design turns on one property: <b>if any participant wants a session, every participant is called
+    /// for every retainer visited.</b> A participant therefore never needs a trigger whose only purpose is
+    /// to justify a trip — it is guaranteed a seat on any trip that happens.
+    /// </para>
+    /// <para>
+    /// The broker never travels between worlds. Being on the home world is a precondition, not something it
+    /// arranges, so a product that wants retainers reached from elsewhere must get there itself. It does walk
+    /// the character to a summoning bell, and it does not restore position afterwards: snapshot it before
+    /// calling and restore it if <see cref="RetainerSessionResult.Moved"/> is <see langword="true"/>.
+    /// </para>
+    /// <para>
+    /// This type is a published integration surface. Once released it evolves additively only — new members
+    /// go on the context object or a new interface, never on
+    /// <see cref="IRetainerSessionParticipant"/> — because a consumer binding to an older LlamaLibrary at
+    /// runtime fails to load entirely if the interface it compiled against has changed shape.
+    /// </para>
+    /// </remarks>
+    public static class RetainerSessionBroker
+    {
+        /// <summary>
+        /// The hard ceiling on passes over the retainers in a single session, regardless of how many
+        /// participants keep calling <see cref="RetainerSessionContext.RequestAdditionalPass"/>.
+        /// </summary>
+        public const int MaxPasses = 3;
+
+        /// <summary>
+        /// How many consecutive callback failures retire a participant.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The streak spans <b>every</b> callback on <see cref="IRetainerSessionParticipant"/>, including
+        /// <see cref="IRetainerSessionParticipant.WantsSession"/> and
+        /// <see cref="IRetainerSessionParticipant.RetainersOfInterest"/>. A participant that throws on every
+        /// poll therefore retires after three polls rather than logging at poll cadence indefinitely. Any
+        /// successful callback clears the streak.
+        /// </para>
+        /// <para>
+        /// A retired participant receives no further callbacks and is named in
+        /// <see cref="RetainerSessionResult.RetiredParticipants"/>. The retirement is logged once, as a
+        /// warning naming the failing stage, so a support log can explain why a feature went quiet rather
+        /// than leaving it silently skipped. Calling <see cref="Register"/> again — which a plugin reload
+        /// does — clears the retirement and gives the participant a fresh start.
+        /// </para>
+        /// </remarks>
+        public const int MaxConsecutiveFailures = 3;
+
+        private static readonly LLogger Log = new(nameof(RetainerSessionBroker), Colors.Gold);
+
+        private static readonly object SyncRoot = new();
+
+        private static readonly List<IRetainerSessionParticipant> Registered = new();
+
+        /// <summary>
+        /// Consecutive failure streaks per participant id. Outlives individual sessions so that failures
+        /// during the poll stage, which happens outside any session, still accumulate toward retirement.
+        /// </summary>
+        private static readonly Dictionary<string, int> ConsecutiveFailures = new(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Participants currently retired. Cleared for a participant when it registers again.
+        /// </summary>
+        private static readonly HashSet<string> RetiredParticipants = new(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Exit NPCs for the three Grand Company barracks.
+        /// </summary>
+        private static readonly uint[] BarracksExitNpcIds = { 2007528, 2006963, 2007530 };
+
+        /// <summary>
+        /// The individual capability flags, in the order claims are resolved and reported.
+        /// </summary>
+        private static readonly RetainerCapability[] SingleCapabilities =
+        {
+            RetainerCapability.Ventures,
+            RetainerCapability.Gil,
+            RetainerCapability.Entrust,
+            RetainerCapability.Pricing,
+            RetainerCapability.Posting,
+        };
+
+        private static bool _sessionInProgress;
+
+        /// <summary>
+        /// Gets a value indicating whether a session is currently running.
+        /// </summary>
+        public static bool SessionInProgress
+        {
+            get
+            {
+                lock (SyncRoot)
+                {
+                    return _sessionInProgress;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the ids of the currently registered participants, in execution order.
+        /// </summary>
+        public static IReadOnlyList<string> Participants
+        {
+            get
+            {
+                lock (SyncRoot)
+                {
+                    return Registered.OrderBy(p => p.Priority).Select(p => p.Id).ToList();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Registers a participant, replacing any existing registration with the same
+        /// <see cref="IRetainerSessionParticipant.Id"/>.
+        /// </summary>
+        /// <param name="participant">The participant to register.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="participant"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><see cref="IRetainerSessionParticipant.Id"/> is null or whitespace.</exception>
+        /// <remarks>
+        /// <para>
+        /// Registration is an upsert keyed on <see cref="IRetainerSessionParticipant.Id"/>, never an append.
+        /// This matters because RebornBuddy rebuilds plugins on reload while this registry persists: an
+        /// appending registry would leave a stale participant behind after every reload, running its work
+        /// twice per retainer and pinning the replaced assembly in memory. Registering the same id again
+        /// swaps the old instance out.
+        /// </para>
+        /// <para>
+        /// Registering also clears any retirement and failure streak for that id, so a reload gives a
+        /// participant a clean slate. Call this from your plugin's enable path; registering during a session
+        /// takes effect on the next one.
+        /// </para>
+        /// </remarks>
+        public static void Register(IRetainerSessionParticipant participant)
+        {
+            if (participant == null)
+            {
+                throw new ArgumentNullException(nameof(participant));
+            }
+
+            if (string.IsNullOrWhiteSpace(participant.Id))
+            {
+                throw new ArgumentException("A participant must have a non-empty Id.", nameof(participant));
+            }
+
+            bool replaced;
+            lock (SyncRoot)
+            {
+                replaced = Registered.RemoveAll(p => string.Equals(p.Id, participant.Id, StringComparison.Ordinal)) > 0;
+                Registered.Add(participant);
+                ConsecutiveFailures.Remove(participant.Id);
+                RetiredParticipants.Remove(participant.Id);
+            }
+
+            Log.Information($"{(replaced ? "Replaced" : "Registered")} participant {participant.Id} (priority {participant.Priority}).");
+        }
+
+        /// <summary>
+        /// Removes a participant and forgets its failure history.
+        /// </summary>
+        /// <param name="participantId">The <see cref="IRetainerSessionParticipant.Id"/> to remove.</param>
+        /// <returns><see langword="true"/> if a participant was removed; otherwise <see langword="false"/>.</returns>
+        /// <remarks>Call from your plugin's disable path. A session already in flight still calls the removed participant.</remarks>
+        public static bool Unregister(string participantId)
+        {
+            int removed;
+            lock (SyncRoot)
+            {
+                removed = Registered.RemoveAll(p => string.Equals(p.Id, participantId, StringComparison.Ordinal));
+                ConsecutiveFailures.Remove(participantId);
+                RetiredParticipants.Remove(participantId);
+            }
+
+            if (removed > 0)
+            {
+                Log.Information($"Unregistered participant {participantId}.");
+            }
+
+            return removed > 0;
+        }
+
+        /// <summary>
+        /// Polls the participants and, if any of them wants one, makes a single trip to the summoning bell.
+        /// </summary>
+        /// <returns>The outcome of the session.</returns>
+        /// <exception cref="CoroutineStoppedException">
+        /// The bot was stopped or the behavior swapped out mid-session. Deliberately propagated rather than
+        /// caught, so the coroutine unwinds instead of the trip continuing to drive retainer windows after
+        /// the bot was told to stop. The re-entrancy guard is released on the way out.
+        /// </exception>
+        /// <remarks>
+        /// <para>
+        /// Safe to call from more than one scheduler and safe to call often. When nobody wants a session the
+        /// cost is one memory-read snapshot plus one <see cref="IRetainerSessionParticipant.WantsSession"/>
+        /// call per participant, with no window interaction and no network traffic of the broker's own.
+        /// </para>
+        /// <para>
+        /// Apart from <see cref="CoroutineStoppedException"/>, participant exceptions are caught and reported
+        /// on the result rather than thrown.
+        /// </para>
+        /// </remarks>
+        public static async Task<RetainerSessionResult> RunIfWanted()
+        {
+            List<IRetainerSessionParticipant> participants;
+
+            lock (SyncRoot)
+            {
+                if (_sessionInProgress)
+                {
+                    return RetainerSessionResult.Skipped(RetainerSessionOutcome.AlreadyRunning, "A retainer session is already running.");
+                }
+
+                participants = Registered
+                    .Where(p => !RetiredParticipants.Contains(p.Id))
+                    .OrderBy(p => p.Priority)
+                    .ToList();
+
+                if (participants.Count == 0)
+                {
+                    return RetainerSessionResult.Skipped(RetainerSessionOutcome.NoParticipants, "No participants are registered.");
+                }
+
+                _sessionInProgress = true;
+            }
+
+            try
+            {
+                return await RunSession(participants);
+            }
+            finally
+            {
+                // Released in a finally so that a CoroutineStoppedException mid-trip cannot leave the guard
+                // held and the broker wedged until RebornBuddy restarts.
+                lock (SyncRoot)
+                {
+                    _sessionInProgress = false;
+                }
+            }
+        }
+
+        private static async Task<RetainerSessionResult> RunSession(List<IRetainerSessionParticipant> participants)
+        {
+            var failures = new Dictionary<string, int>(StringComparer.Ordinal);
+
+            if (OrderbotHook.DefaultBusyCheck())
+            {
+                return RetainerSessionResult.Skipped(RetainerSessionOutcome.Busy, "Character is busy.");
+            }
+
+            if (!WorldHelper.IsOnHomeWorld)
+            {
+                return RetainerSessionResult.Skipped(RetainerSessionOutcome.NotOnHomeWorld, "Not on the home world; retainers are only reachable there.");
+            }
+
+            // Poll with the cheap read. Once the retainer data pointer is populated this is pure memory
+            // access; on a fresh login the first call populates it. Only after a participant commits to a
+            // trip is the forced refresh — which costs a retainer data packet and up to six seconds of
+            // waiting — worth paying for.
+            var pollSnapshot = ActiveRetainers(await HelperFunctions.GetOrderedRetainerArray());
+            if (pollSnapshot.Length == 0)
+            {
+                return RetainerSessionResult.Skipped(RetainerSessionOutcome.NoRetainers, "No active retainers.");
+            }
+
+            var requestedBy = new List<string>();
+            foreach (var participant in Active(participants))
+            {
+                try
+                {
+                    if (await participant.WantsSession(pollSnapshot))
+                    {
+                        requestedBy.Add(participant.Id);
+                    }
+
+                    RecordSuccess(participant.Id);
+                }
+                catch (CoroutineStoppedException)
+                {
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    RecordFailure(participant.Id, "WantsSession", failures);
+                    Log.Error($"[{participant.Id}] WantsSession threw, treating as no: {e}");
+                }
+            }
+
+            if (requestedBy.Count == 0)
+            {
+                return RetainerSessionResult.Skipped(RetainerSessionOutcome.NoWorkWanted, "No participant wants a session.");
+            }
+
+            // Committed to a trip: re-read from the server so the shared snapshot is current.
+            var snapshot = ActiveRetainers(await HelperFunctions.GetOrderedRetainerArray(true));
+            if (snapshot.Length == 0)
+            {
+                return RetainerSessionResult.Skipped(RetainerSessionOutcome.NoRetainers, "No active retainers after refresh.");
+            }
+
+            // Claims are read here, once, after the trip is committed and before any callback runs. Never at
+            // registration time, so a participant whose claims depend on configuration is read as configured
+            // now rather than as configured when its plugin was enabled.
+            var context = new RetainerSessionContext(snapshot, ResolveClaims(Active(participants)), requestedBy);
+            Log.Information($"Session requested by {string.Join(", ", requestedBy)}. Claims: {context.DescribeClaims()}.");
+
+            await GeneralFunctions.StopBusy(dismount: false);
+
+            if (!await LeaveBarracks())
+            {
+                return RetainerSessionResult.Failed(RetainerSessionOutcome.BellFailed, "Could not leave the Grand Company barracks.", failures, CurrentlyRetired());
+            }
+
+            if (!await HelperFunctions.GoToSummoningBell())
+            {
+                return RetainerSessionResult.Failed(RetainerSessionOutcome.BellFailed, "Could not reach a summoning bell.", failures, CurrentlyRetired());
+            }
+
+            if (!await HelperFunctions.OpenRetainerList())
+            {
+                return RetainerSessionResult.Failed(RetainerSessionOutcome.BellFailed, "Could not open the retainer list.", failures, CurrentlyRetired());
+            }
+
+            var visited = new List<ulong>();
+            var passes = 0;
+
+            for (var pass = 1; pass <= MaxPasses; pass++)
+            {
+                passes = pass;
+                context.BeginPass(pass);
+
+                foreach (var participant in Active(participants))
+                {
+                    await Invoke(failures, participant, "OnSessionStarting", () => participant.OnSessionStarting(context));
+                }
+
+                var visitSet = BuildVisitSet(Active(participants), context, failures);
+                if (visitSet.Count == 0)
+                {
+                    Log.Information(pass == 1 ? "No retainer needs visiting." : $"Pass {pass} has nothing left to do.");
+                    break;
+                }
+
+                Log.Information($"Pass {pass}: visiting {visitSet.Count} retainer(s).");
+
+                foreach (var retainerId in visitSet)
+                {
+                    if (!context.TryGetRetainer(retainerId, out var retainer))
+                    {
+                        continue;
+                    }
+
+                    if (!await RetainerRoutine.SelectRetainer(retainerId))
+                    {
+                        Log.Error($"Could not select retainer {retainer.Name}, skipping it.");
+                        continue;
+                    }
+
+                    if (!visited.Contains(retainerId))
+                    {
+                        visited.Add(retainerId);
+                    }
+
+                    foreach (var participant in Active(participants))
+                    {
+                        await Invoke(failures, participant, $"OnRetainer({retainer.Name})", () => participant.OnRetainer(context, retainer));
+                    }
+
+                    await RetainerRoutine.DeSelectRetainer();
+                }
+
+                if (!context.AdditionalPassRequested)
+                {
+                    break;
+                }
+
+                if (pass == MaxPasses)
+                {
+                    Log.Warning($"Another pass was requested but the {MaxPasses}-pass ceiling was reached; stopping here.");
+                }
+            }
+
+            var closed = await CloseList();
+
+            foreach (var participant in Active(participants))
+            {
+                await Invoke(failures, participant, "OnSessionEnded", () => participant.OnSessionEnded(context));
+            }
+
+            var result = RetainerSessionResult.Ran(
+                closed ? RetainerSessionOutcome.Completed : RetainerSessionOutcome.CloseFailed,
+                visited,
+                passes,
+                failures,
+                CurrentlyRetired());
+
+            Log.Information($"Session finished — {result}");
+            return result;
+        }
+
+        /// <summary>
+        /// Filters a retainer array down to the active entries.
+        /// </summary>
+        /// <param name="retainers">The array to filter.</param>
+        /// <returns>Only the retainers marked active.</returns>
+        private static RetainerInfo[] ActiveRetainers(RetainerInfo[] retainers)
+        {
+            return retainers.Where(r => r.Active).ToArray();
+        }
+
+        /// <summary>
+        /// Filters out participants retired since the session started.
+        /// </summary>
+        /// <param name="participants">The session participants, in priority order.</param>
+        /// <returns>The participants still receiving callbacks.</returns>
+        private static List<IRetainerSessionParticipant> Active(List<IRetainerSessionParticipant> participants)
+        {
+            lock (SyncRoot)
+            {
+                return participants.Where(p => !RetiredParticipants.Contains(p.Id)).ToList();
+            }
+        }
+
+        /// <summary>
+        /// Clears a participant's consecutive failure streak after a clean callback.
+        /// </summary>
+        /// <param name="participantId">The participant id.</param>
+        private static void RecordSuccess(string participantId)
+        {
+            lock (SyncRoot)
+            {
+                ConsecutiveFailures.Remove(participantId);
+            }
+        }
+
+        /// <summary>
+        /// Records a failed callback, retiring the participant once it hits
+        /// <see cref="MaxConsecutiveFailures"/> in a row.
+        /// </summary>
+        /// <param name="participantId">The participant id.</param>
+        /// <param name="stage">The callback that failed, named in the retirement warning.</param>
+        /// <param name="sessionFailures">Per-session tally reported on the result.</param>
+        private static void RecordFailure(string participantId, string stage, Dictionary<string, int> sessionFailures)
+        {
+            sessionFailures[participantId] = sessionFailures.TryGetValue(participantId, out var seen) ? seen + 1 : 1;
+
+            bool retire;
+            int streak;
+            lock (SyncRoot)
+            {
+                streak = (ConsecutiveFailures.TryGetValue(participantId, out var consecutive) ? consecutive : 0) + 1;
+                ConsecutiveFailures[participantId] = streak;
+                retire = streak >= MaxConsecutiveFailures && RetiredParticipants.Add(participantId);
+            }
+
+            if (retire)
+            {
+                Log.Warning($"Retiring participant {participantId} after {streak} consecutive failures, most recently in {stage}. Re-enable its plugin to give it another try.");
+            }
+        }
+
+        /// <summary>
+        /// Snapshots the currently retired participant ids for a result.
+        /// </summary>
+        /// <returns>The retired ids.</returns>
+        private static List<string> CurrentlyRetired()
+        {
+            lock (SyncRoot)
+            {
+                return RetiredParticipants.ToList();
+            }
+        }
+
+        /// <summary>
+        /// Assigns each capability to the lowest-priority participant that claims it.
+        /// </summary>
+        /// <param name="participants">Participants already ordered by priority, ascending.</param>
+        /// <returns>A map of capability to owning participant id, omitting capabilities nobody claimed.</returns>
+        private static Dictionary<RetainerCapability, string> ResolveClaims(List<IRetainerSessionParticipant> participants)
+        {
+            var owners = new Dictionary<RetainerCapability, string>();
+
+            foreach (var capability in SingleCapabilities)
+            {
+                foreach (var participant in participants)
+                {
+                    RetainerCapability claims;
+                    try
+                    {
+                        claims = participant.Claims;
+                    }
+                    catch (CoroutineStoppedException)
+                    {
+                        throw;
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error($"[{participant.Id}] Claims threw, treating as None: {e}");
+                        continue;
+                    }
+
+                    if ((claims & capability) == capability)
+                    {
+                        owners[capability] = participant.Id;
+                        break;
+                    }
+                }
+            }
+
+            return owners;
+        }
+
+        /// <summary>
+        /// Builds the union of every participant's retainers of interest, in retainer-list order.
+        /// </summary>
+        /// <param name="participants">The participants still active this session.</param>
+        /// <param name="context">The session context, supplying the snapshot and its ordering.</param>
+        /// <param name="failures">Failure tally to record participants that threw.</param>
+        /// <returns>Content ids to visit this pass.</returns>
+        private static List<ulong> BuildVisitSet(List<IRetainerSessionParticipant> participants, RetainerSessionContext context, Dictionary<string, int> failures)
+        {
+            var interested = new HashSet<ulong>();
+
+            foreach (var participant in participants)
+            {
+                try
+                {
+                    var wanted = participant.RetainersOfInterest(context.Snapshot);
+                    if (wanted != null)
+                    {
+                        foreach (var retainerId in wanted)
+                        {
+                            interested.Add(retainerId);
+                        }
+                    }
+
+                    RecordSuccess(participant.Id);
+                }
+                catch (CoroutineStoppedException)
+                {
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    RecordFailure(participant.Id, "RetainersOfInterest", failures);
+                    Log.Error($"[{participant.Id}] RetainersOfInterest threw, contributing nothing: {e}");
+                }
+            }
+
+            return context.Snapshot.Where(r => interested.Contains(r.Unique)).Select(r => r.Unique).ToList();
+        }
+
+        /// <summary>
+        /// Runs one participant callback, containing any exception so the other participants are unaffected.
+        /// </summary>
+        /// <param name="failures">Failure tally.</param>
+        /// <param name="participant">The participant being invoked.</param>
+        /// <param name="stage">A short label used in the log line.</param>
+        /// <param name="action">The callback.</param>
+        /// <returns><see langword="true"/> if the callback completed; <see langword="false"/> if it threw.</returns>
+        /// <exception cref="CoroutineStoppedException">The bot is stopping; rethrown so the coroutine unwinds.</exception>
+        private static async Task<bool> Invoke(Dictionary<string, int> failures, IRetainerSessionParticipant participant, string stage, Func<Task> action)
+        {
+            try
+            {
+                await action();
+                RecordSuccess(participant.Id);
+                return true;
+            }
+            catch (CoroutineStoppedException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                RecordFailure(participant.Id, stage, failures);
+                Log.Error($"[{participant.Id}] {stage} threw: {e}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Leaves the Grand Company barracks if the character is inside, since no summoning bell is
+        /// reachable from there.
+        /// </summary>
+        /// <returns><see langword="true"/> if the character is out of the barracks; otherwise <see langword="false"/>.</returns>
+        /// <remarks>
+        /// Lives here rather than in a participant because it is a precondition for reaching a bell at all.
+        /// Whichever product triggers the session, the trip has to survive the character being parked in the
+        /// barracks — and <see cref="HelperFunctions.GoToSummoningBell"/> has no handling of its own.
+        /// </remarks>
+        private static async Task<bool> LeaveBarracks()
+        {
+            if (!GrandCompanyHelper.IsInBarracks)
+            {
+                return true;
+            }
+
+            Log.Information("In the Grand Company barracks, leaving so a summoning bell is reachable.");
+
+            var exit = GameObjectManager.GetObjectsByNPCIds<GameObject>(BarracksExitNpcIds).FirstOrDefault();
+            if (exit == null)
+            {
+                Log.Error("Could not find the barracks exit.");
+                return false;
+            }
+
+            if (!await NavigationHelper.InteractWithNpc(exit))
+            {
+                Log.Error("Could not interact with the barracks exit.");
+                return false;
+            }
+
+            if (!await Coroutine.Wait(10000, () => SelectYesno.IsOpen))
+            {
+                Log.Error("The barracks exit confirmation never opened.");
+                return false;
+            }
+
+            SelectYesno.Yes();
+
+            await Coroutine.Wait(10000, () => CommonBehaviors.IsLoading);
+            Log.Information("Waiting for the zone to finish loading.");
+            await Coroutine.Wait(-1, () => !CommonBehaviors.IsLoading);
+
+            return !GrandCompanyHelper.IsInBarracks;
+        }
+
+        /// <summary>
+        /// Closes the retainer list, falling back to a direct close if the helper cannot.
+        /// </summary>
+        /// <returns><see langword="true"/> if the list is closed; otherwise <see langword="false"/>.</returns>
+        private static async Task<bool> CloseList()
+        {
+            if (!RetainerList.Instance.IsOpen)
+            {
+                return true;
+            }
+
+            if (await HelperFunctions.CloseRetainerList())
+            {
+                return true;
+            }
+
+            Log.Error("Could not close the retainer list, trying a direct close.");
+            RetainerList.Instance.Close();
+
+            return await Coroutine.Wait(5000, () => !RetainerList.Instance.IsOpen);
+        }
+    }
+}

--- a/Retainers/Coordination/RetainerSessionBroker.cs
+++ b/Retainers/Coordination/RetainerSessionBroker.cs
@@ -329,7 +329,7 @@ namespace LlamaLibrary.Retainers.Coordination
             // Claims are read here, once, after the trip is committed and before any callback runs. Never at
             // registration time, so a participant whose claims depend on configuration is read as configured
             // now rather than as configured when its plugin was enabled.
-            var context = new RetainerSessionContext(snapshot, ResolveClaims(Active(participants)), requestedBy);
+            var context = new RetainerSessionContext(snapshot, ResolveClaims(Active(participants), failures), requestedBy);
             Log.Information($"Session requested by {string.Join(", ", requestedBy)}. Claims: {context.DescribeClaims()}.");
 
             await GeneralFunctions.StopBusy(dismount: false);
@@ -511,33 +511,42 @@ namespace LlamaLibrary.Retainers.Coordination
         /// Assigns each capability to the lowest-priority participant that claims it.
         /// </summary>
         /// <param name="participants">Participants already ordered by priority, ascending.</param>
+        /// <param name="failures">Failure tally to record participants whose <see cref="IRetainerSessionParticipant.Claims"/> threw.</param>
         /// <returns>A map of capability to owning participant id, omitting capabilities nobody claimed.</returns>
-        private static Dictionary<RetainerCapability, string> ResolveClaims(List<IRetainerSessionParticipant> participants)
+        private static Dictionary<RetainerCapability, string> ResolveClaims(List<IRetainerSessionParticipant> participants, Dictionary<string, int> failures)
         {
+            // Read each participant's Claims exactly once, as the interface contract promises. Reading it
+            // per capability would invoke the getter five times, and a settings change between reads could
+            // tear the claim set: owning Ventures from the old configuration but not Gil from the new.
+            var declared = new List<(string Id, RetainerCapability Claims)>();
+
+            foreach (var participant in participants)
+            {
+                try
+                {
+                    declared.Add((participant.Id, participant.Claims));
+                    RecordSuccess(participant.Id);
+                }
+                catch (CoroutineStoppedException)
+                {
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    RecordFailure(participant.Id, "Claims", failures);
+                    Log.Error($"[{participant.Id}] Claims threw, treating as None: {e}");
+                }
+            }
+
             var owners = new Dictionary<RetainerCapability, string>();
 
             foreach (var capability in SingleCapabilities)
             {
-                foreach (var participant in participants)
+                foreach (var (id, claims) in declared)
                 {
-                    RetainerCapability claims;
-                    try
-                    {
-                        claims = participant.Claims;
-                    }
-                    catch (CoroutineStoppedException)
-                    {
-                        throw;
-                    }
-                    catch (Exception e)
-                    {
-                        Log.Error($"[{participant.Id}] Claims threw, treating as None: {e}");
-                        continue;
-                    }
-
                     if ((claims & capability) == capability)
                     {
-                        owners[capability] = participant.Id;
+                        owners[capability] = id;
                         break;
                     }
                 }

--- a/Retainers/Coordination/RetainerSessionContext.cs
+++ b/Retainers/Coordination/RetainerSessionContext.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LlamaLibrary.Structs;
+
+namespace LlamaLibrary.Retainers.Coordination
+{
+    /// <summary>
+    /// The state shared by every participant in one summoning-bell session: the retainer snapshot, the
+    /// resolved capability owners, and the signals participants use to talk to each other.
+    /// </summary>
+    /// <remarks>
+    /// Created by <see cref="RetainerSessionBroker"/> and passed to every participant callback. Participants
+    /// read <see cref="Snapshot"/> and <see cref="IsOwnedBy"/>, and write through
+    /// <see cref="NotifyItemsMoved"/> and <see cref="RequestAdditionalPass"/>.
+    /// </remarks>
+    public sealed class RetainerSessionContext
+    {
+        private readonly Dictionary<RetainerCapability, string> _owners;
+        private readonly HashSet<string> _movedItemsBy = new(StringComparer.Ordinal);
+        private readonly HashSet<string> _additionalPassBy = new(StringComparer.Ordinal);
+
+        internal RetainerSessionContext(RetainerInfo[] snapshot, Dictionary<RetainerCapability, string> owners, IReadOnlyList<string> requestedBy)
+        {
+            Snapshot = snapshot;
+            _owners = owners;
+            RequestedBy = requestedBy;
+        }
+
+        /// <summary>
+        /// Gets the active retainers as read once at the start of the session, before any participant acted.
+        /// </summary>
+        /// <value>
+        /// The single shared view of retainer state. Every participant sees the same pre-action values, so
+        /// one participant reassigning a venture cannot silently invalidate another's reading of it.
+        /// </value>
+        /// <remarks>
+        /// Deliberately not refreshed mid-session. Fields that a participant's own actions change — a venture
+        /// end timestamp it just moved, a bag it just filled — are stale by design; read those from the game
+        /// when you need them live.
+        /// </remarks>
+        public RetainerInfo[] Snapshot { get; }
+
+        /// <summary>
+        /// Gets the ids of the participants whose <see cref="IRetainerSessionParticipant.WantsSession"/>
+        /// returned <see langword="true"/> and therefore caused this trip.
+        /// </summary>
+        public IReadOnlyList<string> RequestedBy { get; }
+
+        /// <summary>
+        /// Gets the current pass number, starting at 1.
+        /// </summary>
+        /// <value>Incremented when a participant's <see cref="RequestAdditionalPass"/> earns another lap over the retainers.</value>
+        public int Pass { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether this is the first pass over the retainers.
+        /// </summary>
+        /// <value><see langword="true"/> while <see cref="Pass"/> is 1.</value>
+        /// <remarks>
+        /// The pass that owns <see cref="RetainerCapability.Housekeeping"/>. Later passes exist so that items
+        /// moved between retainers can be posted, and re-running housekeeping on them would undo that work —
+        /// entrusting stacks back into a retainer's bag after they were retrieved for exactly the opposite
+        /// reason. <see cref="IsOwnedBy"/> enforces this, so a participant that gates on it needs no
+        /// pass check of its own.
+        /// </remarks>
+        public bool IsFirstPass => Pass <= 1;
+
+        /// <summary>
+        /// Gets a value indicating whether any participant has reported moving items during this pass.
+        /// </summary>
+        /// <value><see langword="true"/> if <see cref="NotifyItemsMoved"/> was called since the pass began.</value>
+        /// <remarks>
+        /// Advisory rather than a precise invalidation protocol: it tells you that a plan built before the
+        /// current pass may be stale, not which entries. Rebuild in
+        /// <see cref="IRetainerSessionParticipant.OnSessionStarting"/> on every pass rather than relying on
+        /// this to be granular.
+        /// </remarks>
+        public bool ItemsMoved => _movedItemsBy.Count > 0;
+
+        /// <summary>
+        /// Gets a value indicating whether another pass over the retainers has been requested.
+        /// </summary>
+        public bool AdditionalPassRequested => _additionalPassBy.Count > 0;
+
+        /// <summary>
+        /// Returns the participant that owns <paramref name="capability"/> for this session.
+        /// </summary>
+        /// <param name="capability">A single capability flag. Composite values such as <see cref="RetainerCapability.Housekeeping"/> are not owned as a unit and always return <see langword="null"/>.</param>
+        /// <returns>
+        /// The owning participant's id, or <see langword="null"/> if nobody claimed it or the capability is
+        /// not available on the current pass.
+        /// </returns>
+        public string? OwnerOf(RetainerCapability capability)
+        {
+            if (!IsAvailableThisPass(capability))
+            {
+                return null;
+            }
+
+            return _owners.TryGetValue(capability, out var owner) ? owner : null;
+        }
+
+        /// <summary>
+        /// Determines whether <paramref name="participantId"/> owns <paramref name="capability"/> and may act
+        /// on it during the current pass.
+        /// </summary>
+        /// <param name="capability">A single capability flag.</param>
+        /// <param name="participantId">The calling participant's <see cref="IRetainerSessionParticipant.Id"/>.</param>
+        /// <returns><see langword="true"/> if this participant should perform the work now; otherwise <see langword="false"/>.</returns>
+        /// <remarks>
+        /// <para>
+        /// The single gate to check before doing any claimed work. It folds together both reasons to stand
+        /// down, so a participant needs no other condition: another participant owns the capability, or the
+        /// capability is closed for this pass.
+        /// </para>
+        /// <para>
+        /// A participant that declared the capability but lost it to a higher-priority participant gets
+        /// <see langword="false"/> and should skip silently — the work is being done by someone else on this
+        /// same trip.
+        /// </para>
+        /// </remarks>
+        public bool IsOwnedBy(RetainerCapability capability, string participantId)
+        {
+            if (!IsAvailableThisPass(capability))
+            {
+                return false;
+            }
+
+            return _owners.TryGetValue(capability, out var owner) && string.Equals(owner, participantId, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Determines whether <paramref name="capability"/> may be acted on during the current pass,
+        /// irrespective of who owns it.
+        /// </summary>
+        /// <param name="capability">A single capability flag.</param>
+        /// <returns><see langword="false"/> for housekeeping capabilities after the first pass; otherwise <see langword="true"/>.</returns>
+        /// <remarks>
+        /// Housekeeping moves items into retainer bags; later passes exist to move items out of them and post
+        /// them. Allowing both in one session would let an entrust on pass two undo a retrieval from pass one.
+        /// </remarks>
+        public bool IsAvailableThisPass(RetainerCapability capability)
+        {
+            return IsFirstPass || (capability & RetainerCapability.Housekeeping) == 0;
+        }
+
+        /// <summary>
+        /// Reports that this participant moved items between the player, a retainer or the saddlebag.
+        /// </summary>
+        /// <param name="participantId">The calling participant's <see cref="IRetainerSessionParticipant.Id"/>.</param>
+        /// <remarks>
+        /// <para>
+        /// <b>Required</b> of any participant that moves an item between the player, a retainer or the
+        /// saddlebag — entrusting, retrieving, collecting venture rewards. Sets <see cref="ItemsMoved"/> for
+        /// the rest of the pass so participants that planned against inventory contents know their plan
+        /// predates a change.
+        /// </para>
+        /// <para>
+        /// Omitting it fails silently rather than loudly: the other participant carries on with a plan that
+        /// names the wrong source or destination for a stack you moved.
+        /// </para>
+        /// </remarks>
+        public void NotifyItemsMoved(string participantId)
+        {
+            _movedItemsBy.Add(participantId);
+        }
+
+        /// <summary>
+        /// Asks the broker for another lap over the retainers before the list is closed.
+        /// </summary>
+        /// <param name="participantId">The calling participant's <see cref="IRetainerSessionParticipant.Id"/>.</param>
+        /// <remarks>
+        /// For work that only becomes possible after a first lap — most obviously retrieving an item from one
+        /// retainer in order to post it on another. The broker recomputes the visit set for each pass and
+        /// stops at <see cref="RetainerSessionBroker.MaxPasses"/> regardless of further requests.
+        /// </remarks>
+        public void RequestAdditionalPass(string participantId)
+        {
+            _additionalPassBy.Add(participantId);
+        }
+
+        /// <summary>
+        /// Returns the snapshot entry for <paramref name="retainerId"/>.
+        /// </summary>
+        /// <param name="retainerId">A retainer content id.</param>
+        /// <param name="retainer">When this returns <see langword="true"/>, the matching snapshot entry.</param>
+        /// <returns><see langword="true"/> if the retainer is in the snapshot; otherwise <see langword="false"/>.</returns>
+        public bool TryGetRetainer(ulong retainerId, out RetainerInfo retainer)
+        {
+            foreach (var candidate in Snapshot)
+            {
+                if (candidate.Unique == retainerId)
+                {
+                    retainer = candidate;
+                    return true;
+                }
+            }
+
+            retainer = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Starts a new pass, clearing the per-pass signals.
+        /// </summary>
+        /// <param name="pass">The pass number, starting at 1.</param>
+        internal void BeginPass(int pass)
+        {
+            Pass = pass;
+            _movedItemsBy.Clear();
+            _additionalPassBy.Clear();
+        }
+
+        /// <summary>
+        /// Returns a short description of the resolved claim ownership, for logging.
+        /// </summary>
+        /// <returns>A comma-separated <c>Capability=Owner</c> list, or a placeholder when nothing was claimed.</returns>
+        internal string DescribeClaims()
+        {
+            return _owners.Count == 0
+                ? "none claimed"
+                : string.Join(", ", _owners.OrderBy(kvp => kvp.Key).Select(kvp => $"{kvp.Key}={kvp.Value}"));
+        }
+    }
+}

--- a/Retainers/Coordination/RetainerSessionResult.cs
+++ b/Retainers/Coordination/RetainerSessionResult.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LlamaLibrary.Retainers.Coordination
+{
+    /// <summary>
+    /// Why a call to <see cref="RetainerSessionBroker.RunIfWanted"/> ended the way it did.
+    /// </summary>
+    public enum RetainerSessionOutcome
+    {
+        /// <summary>The session ran to completion and the retainer list was closed.</summary>
+        Completed,
+
+        /// <summary>Nobody is registered with the broker.</summary>
+        NoParticipants,
+
+        /// <summary>A session is already running. The caller should try again later.</summary>
+        AlreadyRunning,
+
+        /// <summary>The player was moving, occupied, in combat, dead, in an instance or in a FATE.</summary>
+        Busy,
+
+        /// <summary>No active retainers were found.</summary>
+        NoRetainers,
+
+        /// <summary>Every participant declined; no trip was worth making.</summary>
+        NoWorkWanted,
+
+        /// <summary>
+        /// The player is not on their home world, where retainers live.
+        /// </summary>
+        /// <remarks>
+        /// The broker never travels between worlds — it treats being home as a precondition and skips
+        /// otherwise, leaving world travel to whichever product had a reason to move.
+        /// </remarks>
+        NotOnHomeWorld,
+
+        /// <summary>Reached the home world but could not open the retainer list at a summoning bell.</summary>
+        BellFailed,
+
+        /// <summary>The session ran but the retainer list could not be closed afterwards.</summary>
+        CloseFailed,
+    }
+
+    /// <summary>
+    /// The outcome of one <see cref="RetainerSessionBroker"/> session.
+    /// </summary>
+    public sealed class RetainerSessionResult
+    {
+        private RetainerSessionResult(RetainerSessionOutcome outcome, string message, IReadOnlyList<ulong> retainersVisited, int passes, IReadOnlyDictionary<string, int> participantFailures, IReadOnlyList<string> retiredParticipants)
+        {
+            Outcome = outcome;
+            Message = message;
+            RetainersVisited = retainersVisited;
+            Passes = passes;
+            ParticipantFailures = participantFailures;
+            RetiredParticipants = retiredParticipants;
+        }
+
+        /// <summary>Gets the reason the session ended.</summary>
+        public RetainerSessionOutcome Outcome { get; }
+
+        /// <summary>Gets a human-readable summary, suitable for a log line.</summary>
+        public string Message { get; }
+
+        /// <summary>Gets the content ids of the retainers that were selected at least once.</summary>
+        public IReadOnlyList<ulong> RetainersVisited { get; }
+
+        /// <summary>Gets the number of passes made over the retainers.</summary>
+        public int Passes { get; }
+
+        /// <summary>
+        /// Gets the number of callbacks that threw, keyed by participant id.
+        /// </summary>
+        /// <value>Empty when every participant completed cleanly. A participant appearing here still had its other callbacks invoked, unless it was retired.</value>
+        public IReadOnlyDictionary<string, int> ParticipantFailures { get; }
+
+        /// <summary>
+        /// Gets the participants that hit <see cref="RetainerSessionBroker.MaxConsecutiveFailures"/> and were
+        /// dropped for the rest of the session.
+        /// </summary>
+        /// <value>
+        /// Empty in the normal case. A retired participant receives no further callbacks — in this session or
+        /// later ones — until its plugin registers again, and the retirement was logged once with its reason.
+        /// </value>
+        public IReadOnlyList<string> RetiredParticipants { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether a trip was made and completed.
+        /// </summary>
+        /// <value><see langword="true"/> only for <see cref="RetainerSessionOutcome.Completed"/>, regardless of individual participant failures.</value>
+        public bool Success => Outcome == RetainerSessionOutcome.Completed;
+
+        /// <summary>
+        /// Gets a value indicating whether the player was taken to a summoning bell.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> when the session got far enough to walk the character to a summoning bell,
+        /// so the caller knows whether it needs to return to where it was. Never indicates world travel —
+        /// the broker does not move between worlds.
+        /// </value>
+        public bool Moved => Outcome is RetainerSessionOutcome.Completed or RetainerSessionOutcome.BellFailed or RetainerSessionOutcome.CloseFailed;
+
+        /// <summary>
+        /// Creates a result for a session that ended before the character moved.
+        /// </summary>
+        /// <param name="outcome">The reason nothing ran.</param>
+        /// <param name="message">A human-readable summary.</param>
+        /// <returns>A result with no retainers visited and no passes.</returns>
+        internal static RetainerSessionResult Skipped(RetainerSessionOutcome outcome, string message)
+        {
+            return new RetainerSessionResult(outcome, message, Array.Empty<ulong>(), 0, new Dictionary<string, int>(StringComparer.Ordinal), Array.Empty<string>());
+        }
+
+        /// <summary>
+        /// Creates a result for a session that started but could not finish.
+        /// </summary>
+        /// <param name="outcome">The reason the session stopped.</param>
+        /// <param name="message">A human-readable summary.</param>
+        /// <param name="failures">Participant callback failures recorded so far.</param>
+        /// <param name="retired">Participants dropped for the session.</param>
+        /// <returns>A failed result carrying whatever progress was made.</returns>
+        internal static RetainerSessionResult Failed(RetainerSessionOutcome outcome, string message, IReadOnlyDictionary<string, int> failures, IReadOnlyList<string> retired)
+        {
+            return new RetainerSessionResult(outcome, message, Array.Empty<ulong>(), 0, failures, retired);
+        }
+
+        /// <summary>
+        /// Creates a result for a session that ran to completion.
+        /// </summary>
+        /// <param name="outcome">Normally <see cref="RetainerSessionOutcome.Completed"/>, or <see cref="RetainerSessionOutcome.CloseFailed"/> if the window would not close.</param>
+        /// <param name="visited">The retainers selected during the session.</param>
+        /// <param name="passes">The number of passes made.</param>
+        /// <param name="failures">Participant callback failures.</param>
+        /// <param name="retired">Participants dropped for the session.</param>
+        /// <returns>A populated result.</returns>
+        internal static RetainerSessionResult Ran(RetainerSessionOutcome outcome, IReadOnlyList<ulong> visited, int passes, IReadOnlyDictionary<string, int> failures, IReadOnlyList<string> retired)
+        {
+            var failureText = failures.Count == 0
+                ? string.Empty
+                : $", {failures.Sum(kvp => kvp.Value)} participant failure(s): {string.Join(", ", failures.Select(kvp => $"{kvp.Key}x{kvp.Value}"))}";
+
+            var retiredText = retired.Count == 0
+                ? string.Empty
+                : $", retired: {string.Join(", ", retired)}";
+
+            return new RetainerSessionResult(
+                outcome,
+                $"{visited.Count} retainer(s) over {passes} pass(es){failureText}{retiredText}",
+                visited,
+                passes,
+                failures,
+                retired);
+        }
+
+        /// <summary>
+        /// Returns the outcome and message.
+        /// </summary>
+        /// <returns>A string of the form <c>Outcome: message</c>.</returns>
+        public override string ToString()
+        {
+            return $"{Outcome}: {Message}";
+        }
+    }
+}


### PR DESCRIPTION
Adds `RetainerSessionBroker`: a coordination layer so that two products which both want retainer work share one summoning-bell trip instead of racing for it.

Additive only — five new files under `Retainers/Coordination/`, no existing file touched.

## Why

When two products independently drive retainers, each one's trigger is invalidated by the other's actions. Whichever reaches the bell first collects and reassigns ventures, and that single act breaks both sides:

- A product reading **live** venture state loses its evidence — the end timestamp moves into the future and its trigger silently never fires. No error, no log line, just work that stops happening.
- A product reading a **persisted snapshot** now holds a stale one and makes a wasted trip, discovering there is nothing to do only after opening the retainer list.

Both were confirmed against real source on both sides, in LlamaMarket and in Platypus.

## The design

The property everything rests on: **if any participant wants a session, every participant is called for every retainer visited.**

That is what dissolves the problem rather than patching it. A participant no longer needs a trigger whose only purpose is to justify a trip it wanted anyway — it is guaranteed a seat on any trip that happens, so a competing venture resend can no longer cost it a run.

Products register an `IRetainerSessionParticipant` and stop navigating to the bell themselves. Any scheduler may call `RunIfWanted()`; a re-entrancy guard means the first caller in makes the trip. Neither product gives up its own hook or task loop, and neither takes a compile-time dependency on the other — both only know LlamaLibrary.

Notable decisions:

- **One snapshot per session**, shared by every participant, so nobody's view can be corrupted by another participant's actions. The poll uses the cheap memory read; the forced server refresh costs a packet and happens only once a trip is committed.
- **Capability claims** (Ventures, Gil, Entrust, Pricing, Posting) resolve by `Priority`, lowest wins, read once per session so they can be keyed on configuration rather than cached at registration.
- **Housekeeping runs on the first pass only**, enforced by `IsOwnedBy` rather than by convention, so a later retrieve/repost lap cannot entrust the same stacks back into a retainer's bag.
- **Registration is an upsert** keyed on `Id`. RebornBuddy rebuilds plugins on reload while this registry persists, so an appending registry would leave a stale participant running its work twice and pin the replaced assembly.
- **`CoroutineStoppedException` propagates** rather than counting as a failure, so a bot stop unwinds the trip instead of continuing to drive windows. The re-entrancy guard is released in a `finally`.
- **Three consecutive failures retire a participant**, logged once with the failing stage. The streak spans every callback including `WantsSession`, which happens outside any session, so participant health outlives the session and clears when the plugin registers again.
- **Never travels between worlds** — home world is a precondition, not something the broker arranges. It does leave the Grand Company barracks and walk to a bell, since `GoToSummoningBell` has no barracks handling of its own.

## Contract freeze

`IRetainerSessionParticipant` is a published integration surface. A consumer that compiles against one LlamaLibrary and binds to another at runtime fails to load outright — not gracefully — taking its whole botbase with it. It therefore evolves additively only, via the context object or a new interface, never as new members on the interface. That is stated in the XML docs so it survives contact with future edits.

## Review

Reviewed by RedWine82 (Platypus) against the implementation his port will target, in #118, which is included here. That review caught a genuine contract violation: `ResolveClaims` invoked the `Claims` getter once per capability rather than once per session as documented, so a settings change mid-resolution could tear the claim set — owning Ventures from the old configuration but not Gil from the new. It also closed a gap where a throwing `Claims` getter was the one callback exempt from the failure-streak policy.

## Testing

- `dotnet build -c Debug`, both TFMs (`net8.0-windows`, `net10.0-windows`): 0 errors. Remaining warnings are pre-existing in unrelated files.
- Exercised end to end in a live RebornBuddy session driving LlamaMarket: venture collection and resend, price adjustment, cross-retainer item retrieval, and posting, across multiple retainers in one trip.

**Known coverage gap:** every live run so far had a single registered participant. Claim resolution between competing claimants, priority ordering across products, and the first-pass housekeeping rule are exercised by unit-level reasoning but not yet by a real two-participant session. The Platypus port will be the first of those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
