### PR TITLE
Add Beastmaster window discovery and diagnostic foundation

### DIFF
--- a/Docs/Beastmaster.md
+++ b/Docs/Beastmaster.md
@@ -26,10 +26,28 @@ an RB coroutine when closed and uses `/bestiary`; the other wrappers' `Open()`
 methods only report existing visibility because independent opening is not mapped.
 Inherited `SendAction` remains a low-level API, not verified Beastmaster support.
 
-The supplied name `XBMMonsterBookDetail` differs from the upstream symbol
-`XBMMonsterNotebookDetail`. Capture discovers all visible XBM names rather than
-silently treating those names as equivalent. The purpose of `XBMActivePet` relative
-to the Battlehorn Settings screen also remains to be confirmed.
+The live capture confirms `XBMMonsterBookDetail`, differing from the upstream
+`XBMMonsterNotebookDetail` symbol. The wrapper uses the observed runtime name.
+The purpose of `XBMActivePet` relative to Battlehorn Settings remains unconfirmed.
+
+## First live capture (2026-09-08)
+
+Chris supplied a diagnostic capture with Cu Sith selected (attachment
+`ce87cae4-6969-4a74-af30-612b9a2614d6/pasted-text.txt`). Both book addons report
+agent 500. The detail addon exposes zero ATK values; `XBMMonsterNotebook` exposes
+284, including the selected familiar's label/name at 229/230 and habitat text at
+257. A candidate grid occupies values 24 through 223, with 25 repeated groups of
+eight values and labels No. 1 through No. 25. These are observations of one state,
+not validated public field mappings or creature IDs.
+
+The capture contains no ContextMenu or active-pet addon. It cannot establish
+the three horn assignments. A stored "Team Composition" label also does not prove
+that the current UI is in Crucible mode; hidden controls can retain their labels.
+
+Scalar union storage contains unrelated high bytes, for example UInt
+`0x7FF600000001` represents UInt 1. Diagnostics now include the existing TwoInt
+typed Bool/Int/UInt interpretation alongside raw storage so before/after comparison
+does not mistake unused bytes for creature IDs or state changes.
 
 ## Live evidence required
 
@@ -63,6 +81,7 @@ upstream addresses above are only navigation hints, not runtime offsets.
 
 ## Validation boundary
 
-Compile both target frameworks. Runtime opening, addon spelling, typed value
-capture, and all assignment behavior require live validation; a successful build
-does not prove those client behaviors. No CN/TC Beastmaster behavior is claimed.
+Compile both target frameworks. The first capture validates runtime addon spelling
+and the basic capture path. Runtime opening, the updated typed scalar display, and
+all assignment behavior still require live validation; a successful build does not
+prove those client behaviors. No CN/TC Beastmaster behavior is claimed.

--- a/Docs/Beastmaster.md
+++ b/Docs/Beastmaster.md
@@ -1,0 +1,68 @@
+﻿# Beastmaster battlehorn integration
+
+This foundation gives callers named windows and a read-only evidence capture while
+the assignment protocol is being mapped. It does **not** assign a familiar yet.
+Keeping discovery separate prevents an unverified callback from modifying the wrong
+horn or confusing ordinary assignments with Crucible team composition.
+
+## Sources and migration boundary
+
+Checked FFXIVClientStructs commit `bb007e6fcab551dfdb53ad777f4324a9246c9a01` on
+2026-09-08. Its `ida/data.yml` identifies client build `2026.09.01.0000.0000`.
+
+- [Native symbol database](https://github.com/aers/FFXIVClientStructs/blob/bb007e6fcab551dfdb53ad777f4324a9246c9a01/ida/data.yml):
+  notebook, notebook detail, active-pet, and pet-party addon constructors/vtables.
+- [Agent IDs](https://github.com/aers/FFXIVClientStructs/blob/bb007e6fcab551dfdb53ad777f4324a9246c9a01/FFXIVClientStructs/FFXIV/Client/UI/Agent/AgentModule.cs):
+  notebook 500 and pet-party 501 are research leads, not portable registrations.
+- `XBMModule` and `XBMNoteModule` only expose their inherited user-file event and
+  instance accessors. They have no mapped assignment fields or methods to migrate.
+- [Official 7.56 notes](https://eu.finalfantasyxiv.com/lodestone/topics/detail/d979aeaccd188ce59ea4eef8c51c26037fd5b06a):
+  `/bestiary` toggles the book; its subcommand assigns familiars to battlehorns.
+
+The wrappers reuse `RemoteWindow<T>`, its `TwoInt` reader, existing ATK offsets,
+and normal timeout behavior. No native layouts, signatures, absolute addresses,
+or fixed agent registrations were introduced. `XBMMonsterNotebook.Open()` requires
+an RB coroutine when closed and uses `/bestiary`; the other wrappers' `Open()`
+methods only report existing visibility because independent opening is not mapped.
+Inherited `SendAction` remains a low-level API, not verified Beastmaster support.
+
+The supplied name `XBMMonsterBookDetail` differs from the upstream symbol
+`XBMMonsterNotebookDetail`. Capture discovers all visible XBM names rather than
+silently treating those names as equivalent. The purpose of `XBMActivePet` relative
+to the Battlehorn Settings screen also remains to be confirmed.
+
+## Live evidence required
+
+With a current Global 7.56 client attached to RB, stop the bot and open the bestiary.
+Run this complete statement in RebornConsole after loading this library build:
+
+```csharp
+Log(LlamaLibrary.Helpers.BeastmasterDiagnostics.Capture());
+```
+
+Capture each of these states and retain which familiar/horn was selected:
+
+1. A captured familiar selected in the book.
+2. Its assignment context menu open, including disabled horn choices.
+3. Battlehorn Settings before and after manually assigning that familiar.
+4. A second familiar assigned to the same horn, and assignment to each unlocked horn.
+
+Also record the character's Beastmaster level and which horns are unlocked. These
+snapshots establish candidate value fields and actual addon/agent names, but **do not
+capture callbacks**. A UI callback trace or disassembly of the notebook/context-menu
+handler is still required to establish the callback value types, argument order,
+creature identifier (row ID versus display index), and horn indexing convention.
+Do not guess that an enabled menu row index is a fixed horn index.
+
+Before exposing an assignment API, verify success by reading the resulting slot,
+confirm behavior for uncaptured creatures and unavailable horns, and determine the
+client's combat/reassignment restrictions. If native signatures become necessary,
+derive operand wildcards from Ghidra instruction semantics and verify unique matches
+and extraction results on every available supported regional/prior build. The
+upstream addresses above are only navigation hints, not runtime offsets.
+
+## Validation boundary
+
+Compile both target frameworks. Runtime opening, addon spelling, typed value
+capture, and all assignment behavior require live validation; a successful build
+does not prove those client behaviors. No CN/TC Beastmaster behavior is claimed.

--- a/Helpers/BeastmasterDiagnostics.cs
+++ b/Helpers/BeastmasterDiagnostics.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using ff14bot;
+using ff14bot.Managers;
+using LlamaLibrary.RemoteWindows;
+using AtkValueType = LlamaLibrary.RemoteWindows.Atk.ValueType;
+
+namespace LlamaLibrary.Helpers
+{
+    /// <summary>Captures read-only Beastmaster UI evidence needed to map battlehorn assignment.</summary>
+    /// <remarks>
+    /// Uses the existing RemoteWindow/TwoInt reader and signature-resolved ATK offsets.
+    /// No XBM field offsets, agent IDs, or callback values are assumed. Output is materialized
+    /// while the frame is held so callers do not retain live string pointers after the capture.
+    /// </remarks>
+    public static class BeastmasterDiagnostics
+    {
+        /// <summary>Describes visible XBM addons and the context menu without sending UI actions.</summary>
+        /// <returns>A text snapshot of addon names, associated agent IDs, and typed ATK values; an explicit message if none are visible.</returns>
+        /// <remarks>
+        /// Call with RB attached and initialized, preferably with the bot stopped from RebornConsole.
+        /// GetRawControls avoids reliance on another thread's cached window list. The frame lock
+        /// is held only for synchronous reads; there are no waits or coroutine operations.
+        /// Only string-tagged values are dereferenced; vectors and unknown types remain raw data.
+        /// A value snapshot does not capture callbacks and cannot establish their parameter order.
+        /// </remarks>
+        public static string Capture()
+        {
+            var text = new StringBuilder();
+            using (Core.Memory.AcquireFrame())
+            using (Core.Memory.TemporaryCacheState(false))
+            {
+                var controls = RaptureAtkUnitManager.GetRawControls
+                    .Where(control => control != null && control.IsVisible &&
+                        (control.Name.StartsWith("XBM", StringComparison.Ordinal) || control.Name == "ContextMenu"))
+                    .ToArray();
+
+                foreach (var control in controls)
+                {
+                    var agent = control.TryFindAgentInterface();
+                    text.AppendLine($"{control.Name}: agent={agent?.Id.ToString() ?? "unresolved"}");
+                    WindowReader.AppendValues(text, control);
+                }
+
+                if (controls.Length == 0)
+                {
+                    text.AppendLine("No visible XBM addons or ContextMenu. Open the Master's Bestiary first.");
+                }
+            }
+
+            return text.ToString();
+        }
+
+        // A private adapter exposes the established protected reader without expanding RemoteWindow's
+        // public API or duplicating its client-specific ATK count/pointer extraction.
+        private sealed class WindowReader : RemoteWindow
+        {
+            private WindowReader() : base(string.Empty)
+            {
+            }
+
+            internal static void AppendValues(StringBuilder text, AtkAddonControl control)
+            {
+                var values = ReadElements(control);
+                text.AppendLine($"  AtkValues={values.Length}");
+                for (var index = 0; index < values.Length; index++)
+                {
+                    var value = values[index];
+                    var type = (AtkValueType)value.Type;
+                    var baseType = type & AtkValueType.TypeMask;
+                    var description = $"  [{index}] type={type} data=0x{value.Data:X}";
+                    if ((baseType == AtkValueType.String || baseType == AtkValueType.String8) && value.Data != 0)
+                    {
+                        // Bound diagnostic string reads to 1 KiB: labels are short, and an unexpected
+                        // client layout must not turn a UI probe into an unbounded remote-memory scan.
+                        var label = Core.Memory.ReadString((IntPtr)value.Data, Encoding.UTF8, 1024);
+                        description += " text=" + label.Replace("\r", "\\r").Replace("\n", "\\n");
+                    }
+
+                    text.AppendLine(description);
+                }
+            }
+        }
+    }
+}

--- a/Helpers/BeastmasterDiagnostics.cs
+++ b/Helpers/BeastmasterDiagnostics.cs
@@ -70,6 +70,22 @@ namespace LlamaLibrary.Helpers
                     var type = (AtkValueType)value.Type;
                     var baseType = type & AtkValueType.TypeMask;
                     var description = $"  [{index}] type={type} data=0x{value.Data:X}";
+                    // ATK's union can retain unrelated upper bytes when the client writes a
+                    // smaller scalar. The first 7.56 capture demonstrated this for UInt/Bool.
+                    // Decode the tagged width; retain the raw union only as diagnostic evidence.
+                    switch (baseType)
+                    {
+                        case AtkValueType.Bool:
+                            description += $" value={value.Bool}";
+                            break;
+                        case AtkValueType.Int:
+                            description += $" value={value.Int}";
+                            break;
+                        case AtkValueType.UInt:
+                            description += $" value={value.UInt}";
+                            break;
+                    }
+
                     if ((baseType == AtkValueType.String || baseType == AtkValueType.String8) && value.Data != 0)
                     {
                         // Bound diagnostic string reads to 1 KiB: labels are short, and an unexpected

--- a/RemoteWindows/XBMActivePet.cs
+++ b/RemoteWindows/XBMActivePet.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+
+namespace LlamaLibrary.RemoteWindows
+{
+    /// <summary>Provides access to the Beastmaster active-pet addon identified by FFXIVClientStructs.</summary>
+    /// <remarks>
+    /// The name is mapped in FFXIVClientStructs bb007e6f, but its relationship to Battlehorn Settings
+    /// and its slot fields still require live verification. Do not interpret this window as Crucible
+    /// team composition or assume its values are summon action IDs. See Docs/Beastmaster.md.
+    /// </remarks>
+    public class XBMActivePet : RemoteWindow<XBMActivePet>
+    {
+        /// <summary>Creates a wrapper that looks up the active-pet addon without retaining its native pointer.</summary>
+        public XBMActivePet() : base("XBMActivePet")
+        {
+        }
+
+        /// <summary>Checks whether the game has already opened the active-pet addon.</summary>
+        /// <returns>A completed task containing true when visible, or false when the UI must first open it.</returns>
+        /// <remarks>No opening callback is verified yet, so this does not toggle an unregistered agent.</remarks>
+        public override Task<bool> Open() => Task.FromResult(IsOpen);
+    }
+}

--- a/RemoteWindows/XBMMonsterBookDetail.cs
+++ b/RemoteWindows/XBMMonsterBookDetail.cs
@@ -4,14 +4,15 @@ namespace LlamaLibrary.RemoteWindows
 {
     /// <summary>Provides access to the selected familiar's detail page in the Master's Bestiary.</summary>
     /// <remarks>
-    /// FFXIVClientStructs bb007e6f names this addon XBMMonsterNotebookDetail. The reported
-    /// XBMMonsterBookDetail spelling remains unverified; capture live addon names before adding an alias.
+    /// The live 7.56 capture confirms XBMMonsterBookDetail, despite FFXIVClientStructs bb007e6f's
+    /// XBMMonsterNotebookDetail symbol. Both book windows report agent 500 in that capture;
+    /// this detail addon has no ATK values of its own, while the notebook carries the selected details.
     /// Selection and assignment callback arguments are intentionally left unmapped until observed.
     /// </remarks>
-    public class XBMMonsterNotebookDetail : RemoteWindow<XBMMonsterNotebookDetail>
+    public class XBMMonsterBookDetail : RemoteWindow<XBMMonsterBookDetail>
     {
         /// <summary>Creates a wrapper for the client-owned selected-familiar detail page.</summary>
-        public XBMMonsterNotebookDetail() : base("XBMMonsterNotebookDetail")
+        public XBMMonsterBookDetail() : base("XBMMonsterBookDetail")
         {
         }
 

--- a/RemoteWindows/XBMMonsterNotebook.cs
+++ b/RemoteWindows/XBMMonsterNotebook.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading.Tasks;
+using Buddy.Coroutines;
+using ff14bot.Managers;
+
+namespace LlamaLibrary.RemoteWindows
+{
+    /// <summary>Provides access to the Master's Bestiary used to select Beastmaster familiars.</summary>
+    /// <remarks>
+    /// The addon identity comes from FFXIVClientStructs bb007e6f (Global 7.56).
+    /// Reuse RemoteWindow's ATK access rather than copying native module layouts or agent IDs.
+    /// Battlehorn assignment callbacks are not yet mapped; inherited SendAction is a raw API,
+    /// not a verified assignment operation. See Docs/Beastmaster.md for the evidence still needed.
+    /// </remarks>
+    public class XBMMonsterNotebook : RemoteWindow<XBMMonsterNotebook>
+    {
+        /// <summary>Creates a wrapper that resolves the visible bestiary each time it is accessed.</summary>
+        public XBMMonsterNotebook() : base("XBMMonsterNotebook")
+        {
+        }
+
+        /// <summary>Opens the bestiary through the game's documented /bestiary command.</summary>
+        /// <returns>True if the bestiary is already visible or becomes visible within the standard window timeout.</returns>
+        /// <exception cref="InvalidOperationException">The window is closed and the caller is outside an RB coroutine.</exception>
+        /// <remarks>
+        /// Run on the bot coroutine, with UI operations serialized. The command toggles the window,
+        /// so it is sent only when closed. No agent number is registered: those IDs vary by client.
+        /// The client retains responsibility for job/unlock restrictions; rejection produces a timeout.
+        /// </remarks>
+        public override async Task<bool> Open()
+        {
+            if (IsOpen)
+            {
+                return true;
+            }
+
+            if (Coroutine.Current == null)
+            {
+                throw new InvalidOperationException("Opening the Master's Bestiary requires an RB coroutine.");
+            }
+
+            ChatManager.SendChat("/bestiary");
+            return await WaitTillWindowOpen();
+        }
+    }
+}

--- a/RemoteWindows/XBMMonsterNotebookDetail.cs
+++ b/RemoteWindows/XBMMonsterNotebookDetail.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading.Tasks;
+
+namespace LlamaLibrary.RemoteWindows
+{
+    /// <summary>Provides access to the selected familiar's detail page in the Master's Bestiary.</summary>
+    /// <remarks>
+    /// FFXIVClientStructs bb007e6f names this addon XBMMonsterNotebookDetail. The reported
+    /// XBMMonsterBookDetail spelling remains unverified; capture live addon names before adding an alias.
+    /// Selection and assignment callback arguments are intentionally left unmapped until observed.
+    /// </remarks>
+    public class XBMMonsterNotebookDetail : RemoteWindow<XBMMonsterNotebookDetail>
+    {
+        /// <summary>Creates a wrapper for the client-owned selected-familiar detail page.</summary>
+        public XBMMonsterNotebookDetail() : base("XBMMonsterNotebookDetail")
+        {
+        }
+
+        /// <summary>Checks whether the detail page has already been opened by selecting a familiar.</summary>
+        /// <returns>A completed task containing true when visible, or false when selection is still required.</returns>
+        /// <remarks>
+        /// This page cannot be opened independently with the evidence currently available.
+        /// Avoid the base implementation's null agent toggle or inventing a creature-selection callback.
+        /// </remarks>
+        public override Task<bool> Open() => Task.FromResult(IsOpen);
+    }
+}


### PR DESCRIPTION
Beastmaster battlehorn assignment has no mapped callbacks or assigned-creature fields in the checked FFXIVClientStructs revision. This adds named bestiary/detail/active-pet wrappers and a read-only diagnostic capture so the remaining protocol can be investigated using LlamaLibrary's existing ATK access.

The bestiary can be opened through the documented /bestiary command from an RB coroutine. Detail and active-pet opening only report visibility until their callbacks are verified. No assignment API, native layout, fixed agent registration, or signature is introduced. The documentation records source provenance, naming uncertainty, required live captures, and the callback-tracing boundary.

Validation: both net8.0-windows and net10.0-windows build successfully, with existing warnings outside these changes. Every changed file was reviewed for durable rationale and public API documentation. Live-client behavior remains unverified; this PR stays draft while assignment is mapped.
