### PR TITLE
Correct regional game patch versions for September 2026

### DIFF
--- a/Memory/OffsetManager.cs
+++ b/Memory/OffsetManager.cs
@@ -116,12 +116,19 @@ public static class OffsetManager
         };
 #endif
 
+        // Patch labels drive shared feature gates (including Beastmaster at 7.56); they are
+        // content versions, not Core.CurrentGameVer executable build numbers. Verified 2026-09-11:
+        // Global: https://na.finalfantasyxiv.com/lodestone/topics/detail/a8a526ad64db45c8ca8d1c7fdcce8a5eedaa18bc
+        // China: https://ff.web.sdo.com/project/launcher/news.asp (official 7.56 patch notes)
+        // Korea: https://www.ff14.co.kr/news/notice/view/2949 (September 8 maintenance completed)
+        // TC: https://www.ffxiv.com.tw/web/news/news_content.aspx?id=mPPBQZMZvm (July 28: 7.2)
+        // Keep regional entries independent: TC must reach the feature's patch before enabling it.
         ActiveRecord = ActiveRegion switch
         {
-            ClientRegion.China              => new GameRecord(7.51f, OffsetFlags.China),
-            ClientRegion.Korea              => new GameRecord(7.31f,  OffsetFlags.Korea),
-            ClientRegion.TraditionalChinese => new GameRecord(7.1f,  OffsetFlags.TraditionalChinese),
-            _                               => new GameRecord(7.51f, OffsetFlags.Global),
+            ClientRegion.China              => new GameRecord(7.56f, OffsetFlags.China),
+            ClientRegion.Korea              => new GameRecord(7.56f, OffsetFlags.Korea),
+            ClientRegion.TraditionalChinese => new GameRecord(7.2f, OffsetFlags.TraditionalChinese),
+            _                               => new GameRecord(7.56f, OffsetFlags.Global),
         };
 
         IsChinese = ActiveRegion == ClientRegion.China;


### PR DESCRIPTION
The regional patch table still reports Global/China as 7.51, Korea as 7.31, and TC as 7.1. This hides patch-gated features such as Beastmaster even on current Global clients.

Update Global, China, and Korea to 7.56 and TC to 7.2, verified against official publisher pages on September 11, 2026. Keep the region flags unchanged and document the sources beside the table. These are content patch versions, not native executable build numbers.

Official sources:
- Global: https://na.finalfantasyxiv.com/lodestone/topics/detail/a8a526ad64db45c8ca8d1c7fdcce8a5eedaa18bc
- China official launcher lists 7.56 patch notes: https://ff.web.sdo.com/project/launcher/news.asp
- Korea completed September 8 maintenance: https://www.ff14.co.kr/news/notice/view/2949
- TC completed July 28 update to 7.2: https://www.ffxiv.com.tw/web/news/news_content.aspx?id=mPPBQZMZvm

Validation: `dotnet build LlamaLibrary.csproj -v:q` passed for net8.0-windows and net10.0-windows, with 14 warnings in the unchanged LoadServerProfile helper and zero errors. Panda Farmer also builds with the shared patch check, without its temporary native-build fallback. No native signatures or extraction behavior changed.
