### PR TITLE
fix(inclusion-shop): number shop items by the line the window shows

### DIFF
--- a/RemoteAgents/AgentInclusionShop.cs
+++ b/RemoteAgents/AgentInclusionShop.cs
@@ -131,20 +131,26 @@ namespace LlamaLibrary.RemoteAgents
                     {
                         var subCategory = Instance.SubCategoryPtrByIndex(category, i);
                         //var enabledByte = Core.Memory.Read<byte>(subCategory + AgentInclusionShopOffsets.SubCategoryEnabled);
-                        var itemNum = 0;
+
+                        // The agent keeps one struct per row, but the window gives every item its own line, so a row
+                        // that gives two items (a sword and its shield) takes two lines. InclusionShop.BuyItem takes
+                        // the line, so walk the structs one row at a time and number them by line.
+                        var row = 0;
+                        var line = 0;
                         InclusionShopItemStruct shopItemStruct;
                         do
                         {
-                            var pointer = subCategory + AgentInclusionShopOffsets.StructSizeCategory + ((AgentInclusionShopOffsets.StructSizeItem + AgentInclusionShopOffsets.ItemStructAdjustment) * itemNum);
+                            var pointer = subCategory + AgentInclusionShopOffsets.StructSizeCategory + ((AgentInclusionShopOffsets.StructSizeItem + AgentInclusionShopOffsets.ItemStructAdjustment) * row);
                             shopItemStruct = Core.Memory.Read<InclusionShopItemStruct>(pointer);
                             if (shopItemStruct.ItemId == 0)
                             {
                                 break;
                             }
 
-                            //shopItems.Add(new InclusionShopItem(shopItemStruct, cat, i, itemNum, (enabledByte & 1) == 1));
-                            shopItems.Add(new InclusionShopItem(shopItemStruct, cat, i, itemNum, false));
-                            itemNum += shopItemStruct.NumberOfItems;
+                            //shopItems.Add(new InclusionShopItem(shopItemStruct, cat, i, line, (enabledByte & 1) == 1));
+                            shopItems.Add(new InclusionShopItem(shopItemStruct, cat, i, line, false));
+                            row++;
+                            line += shopItemStruct.NumberOfItems;
                         }
                         while (shopItemStruct.ItemId > 0);
                     }

--- a/Structs/InclusionShopItem.cs
+++ b/Structs/InclusionShopItem.cs
@@ -24,6 +24,9 @@ namespace LlamaLibrary.Structs
 
         public bool Hidden;
 
+        /// <summary>
+        /// The item's line in the list the window shows, which is what InclusionShop.BuyItem takes. A row that gives two items takes two lines.
+        /// </summary>
         public int Index;
 
         public InclusionShopItem(InclusionShopItemStruct shopItem, byte category, byte subCategory, int location, bool hidden)


### PR DESCRIPTION
`AgentInclusionShop.ShopItems` gives the wrong `Index` to every row that comes after a row with two items, so `InclusionShop.BuyItem` buys the item listed just above the one asked for, and the row right after the two item row is missing from the list altogether.

The agent keeps one struct per row. The walk added each row's `NumberOfItems` to a single counter and used that counter both as the struct slot and as the `Index`. After a two item row (a Paladin sword and shield) it skipped the next struct, and every later row got an `Index` one short of its line. `BuyItem` takes the line in the list the window shows, where the sword and the shield each get a line of their own.

Rowena's representative in Foundation, Tank > Shire Gear (IL 270):

| Line in the window | Item | `Index` before | `Index` after |
|---|---|---|---|
| 0 and 1 | Augmented Shire Sword + Augmented Shire Shield | 0 | 0 |
| 2 | Augmented Shire Bhuj | not listed | 2 |
| 3 | Augmented Shire Greatsword | 2 | 3 |
| 4 | Augmented Shire Bayonet | 3 | 4 |
| 5 | Augmented Shire Custodian's Circlet | 4 | 5 |
| 6 | Augmented Shire Custodian's Armor | 5 | 6 |
| 7 | Augmented Shire Custodian's Gauntlets | 6 | 7 |
| 8 | Augmented Shire Custodian's Hose | 7 | 8 |
| 9 | Augmented Shire Custodian's Sollerets | 8 | 9 |
| 10 | Augmented Shire Custodian's Earrings | 9 | 10 |
| 11 | Augmented Shire Custodian's Choker | 10 | 11 |
| 12 | Augmented Shire Custodian's Bracelet | 11 | 12 |
| 13 | Augmented Shire Custodian's Ring | 12 | 13 |

In game, `BuyItem(9)` opens the exchange dialog for the Sollerets and `BuyItem(10)` for the Earrings, `BuyItem(2)` for the Bhuj and `BuyItem(3)` for the Greatsword. So asking for the Earrings with the old `Index` bought the Sollerets. `InclusionShopHelper.BuyItem` and the `BuyInclusionShopItem` tag in LlamaUtilities both go through `ShopItems`, so they bought the wrong item the same way.

The fix walks the structs one row at a time and sets `Index` to the running line count, where a row with two items takes two lines. `InclusionShopItem.Index` now says it is the line `BuyItem` takes.

I also walked every sub-category of that shop with the new numbering and compared it with the item ids the window lists: all 83 sub-lists (1141 rows) match. The old walk put 65 of those rows one line early and could not see 12 of them, all in the six Tank sub-lists that contain sword and shield rows.
